### PR TITLE
Adding index.yaml to the stacks repo

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+generated: 2019-02-01T13:08:45.039293383Z
+projects:
+  java-microprofile:
+  - created: 2019-02-01T13:08:45.039293383Z
+    description: Java Microprofile Project 
+    digest: c043777f921203f4e03c1dc5089ba9d26d9f353b0df2b239b956200aab5205d6
+    icon: https://
+    keywords:
+    - Java 
+    - Microprofile 
+    - Skeleton 
+    name: java-microprofile
+    home: http://my-home
+    maintainers: 
+    - me
+    - you
+    urls:
+    - https://github.com/appsody/stacks/releases/download/0.0.1-alpha/incubator.java-microprofile.templates.default.tar.gz
+    version: 1.1.0
+  java-spring-boot2:
+  - created: 2019-02-01T13:08:45.039293383Z
+    description: Java Spring Project 
+    digest: c043777f921203f4e03c1dc5089ba9d26d9f353b0df2b239b956200aab5205d6
+    icon: https://
+    keywords:
+    - Java 
+    - Microprofile 
+    - Skeleton 
+    name: java-spring-boot2
+    home: http://my-home
+    maintainers: 
+    - me
+    - you
+    urls:
+    - https://github.com/appsody/stacks/releases/download/0.0.1-alpha/incubator.java-spring-boot2.templates.default.tar.gz
+    version: 1.0.0    
+  nodejs:
+  - created: 2019-02-01T13:08:45.039293383Z
+    description: Node.js Base Project
+    digest: c043777f921203f4e03c1dc5089ba9d26d9f353b0df2b239b956200aab5205d6
+    icon: https://
+    keywords:
+    - Node.js
+    - Base
+    - Skeleton
+    name: nodejs
+    home: http://my-home
+    maintainers:
+    - me
+    urls:
+    - https://github.com/appsody/stacks/releases/download/0.0.1-alpha/incubator.nodejs.templates.simple.tar.gz
+    version: 0.8.0  
+  nodejs-express:
+  - created: 2019-02-01T13:08:45.039293383Z
+    description: Node.js Express Project
+    digest: c043777f921203f4e03c1dc5089ba9d26d9f353b0df2b239b956200aab5205d6
+    icon: https://
+    keywords:
+    - Node.js
+    - Express
+    - Skeleton
+    name: nodejs-express
+    home: http://my-home
+    maintainers:
+    - me
+    urls:
+    - https://github.com/appsody/stacks/releases/download/0.0.1-alpha/incubator.nodejs-express.templates.simple.tar.gz
+    version: 0.8.0
+  


### PR DESCRIPTION
The CLI needs a consistent URL to reference an ever changing index.yaml file. Github releases won't work because the version tag changes in the URL. So we are placing it in the stacks repo and using the github RAW link to access it.