### PR TITLE
[nodejs-express] Remove use of vhost

### DIFF
--- a/incubator/nodejs-express/image/project/package.json
+++ b/incubator/nodejs-express/image/project/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@cloudnative/health-connect": "^2.0.0",
     "appmetrics-prometheus": "^2.0.0",
-    "vhost": "^3.0.2",
     "express": "~4.16.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The use of `vhost` with `*` works on localhost, but fails when running under Knative serving with a mapped domain. As it turns out, the use of vhost isn't required - we can use use `app.use('.
/', userApp)` to register the users application on the root url.

I'm also moved this above the health/liveness/readiness endpoints in order to allow users to override those with their own. 