### PR TITLE
java-microprofile: make the default context root respond nicely

### DIFF
--- a/incubator/java-microprofile/templates/default/src/main/java/dev/appsody/starter/HelloResource.java
+++ b/incubator/java-microprofile/templates/default/src/main/java/dev/appsody/starter/HelloResource.java
@@ -1,0 +1,17 @@
+package dev.appsody.starter;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("")
+public class HelloResource {
+
+	@GET
+	@Produces(MediaType.TEXT_PLAIN)
+	public String getHelloWorld() {
+		return "Hello from Appsody!";
+	}
+
+}

--- a/incubator/java-microprofile/templates/default/src/main/java/dev/appsody/starter/StarterApplication.java
+++ b/incubator/java-microprofile/templates/default/src/main/java/dev/appsody/starter/StarterApplication.java
@@ -3,7 +3,7 @@ package dev.appsody.starter;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
-@ApplicationPath("/starter")
+@ApplicationPath("/")
 public class StarterApplication extends Application {
 
 }

--- a/index.yaml
+++ b/index.yaml
@@ -10,11 +10,11 @@ projects:
     - Microprofile
     - Maven
     - Open Liberty
-    name: java-microprofile
+    name: java-microprofile-mct
     maintainers:
     - neeraj.laad@gmail.com
     urls:
-    - https://github.com/appsody/stacks/releases/download/0.2.1/incubator.java-microprofile.templates.default.tar.gz
+    - https://github.com/barecode/stacks/releases/download/0.2.1/incubator.java-microprofile.templates.default.tar.gz
     version: 0.2.0
   java-spring-boot2:
   - created: 2019-06-24T21:00:00+00:00

--- a/index.yaml
+++ b/index.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 generated: 2019-06-24T21:00:00+00:00
 projects:
-  java-microprofile:
+  java-microprofile-mct:
   - created: 2019-06-24T21:00:00+00:00
     description: Microprofile using Adopt OpenJDK and Maven
     icon: https://


### PR DESCRIPTION
java-microprofile: make the default context root (localhost:9080) respond with something better than a 404

This change adds a simple Hello World resource to the MicroProfile starter and bind the application to the default context root so that it responds on localhost:9080. When accessed, the user will see "Hello from Appsody!"

Fixes: https://github.com/appsody/stacks/issues/30