### PR TITLE
[java-spring-boot2]: make the default context root respond nicely

### DIFF
--- a/incubator/java-spring-boot2/templates/default/src/main/java/application/HelloController.java
+++ b/incubator/java-spring-boot2/templates/default/src/main/java/application/HelloController.java
@@ -1,0 +1,13 @@
+package application;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @RequestMapping("/")
+    public String hello() {
+        return "Hello from Appsody!";
+    }
+}


### PR DESCRIPTION
This change adds a RestController which responds on localhost:8080 with "Hello from Appsody!"

Fixes: https://github.com/appsody/stacks/issues/31