### PR TITLE
[nodejs] Add appmetrics-dash as a dev dependency

### DIFF
--- a/incubator/nodejs-express/README.md
+++ b/incubator/nodejs-express/README.md
@@ -28,6 +28,12 @@ This stack also comes with Prometheus metrics, which has been preconfigured to w
 
 - Metrics endpoint: http://localhost:3000/metrics
 
+## Application monitoring dashboard (development only)
+
+During development of your application, the nodejs-express stack provides a built-in application performance dashboard using the [appmetrics-dash](https://github.com/runtimetools/appmetrics-dash) module. This makes it easy to see the resource usage and HTTP endpoint performance of your application as it is developed.
+
+The dashboard is only included during development, and is not included in images build using `appsody build`.
+
 ## Templates
 
 Templates are used to create your local project and start your development. When initializing your project you will be provided with the simplest Node.js Express application you can write.
@@ -63,3 +69,4 @@ This template only has a simple `app.js` file which implements the `/` endpoint.
     - Liveness endpoint: http://localhost:3000/live
     - Readiness endpoint: http://localhost:3000/ready
     - Metrics endpoint: http://localhost:3000/metrics
+    - Dashboard endpoint: http://localhost:3000/appmetrics-dash (development only)

--- a/incubator/nodejs-express/image/project/package.json
+++ b/incubator/nodejs-express/image/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-express",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Node.js Express Stack",
   "license": "Apache-2.0",
   "repository": {

--- a/incubator/nodejs-express/image/project/package.json
+++ b/incubator/nodejs-express/image/project/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "~6.1.0",
-    "request": "^2.88.0"
+    "request": "^2.88.0",
+    "appmetrics-dash": "^4.1.0"
   }
 }

--- a/incubator/nodejs-express/image/project/server.js
+++ b/incubator/nodejs-express/image/project/server.js
@@ -1,3 +1,7 @@
+// Requires statements and code for non-production mode usage
+if (!process.env.NODE_ENV || !process.env.NODE_ENV === 'production') {
+  require('appmetrics-dash').attach();
+}
 const express = require('express');
 const health = require('@cloudnative/health-connect');
 const fs = require('fs');

--- a/incubator/nodejs-express/stack.yaml
+++ b/incubator/nodejs-express/stack.yaml
@@ -1,6 +1,6 @@
 id: nodejs-express
 name: Node.js Express application
-version: 0.2.0
+version: 0.2.1
 description: Simple Node.js Express application with health checks and application metrics for Prometheus.
 maintainer: Neeraj Laad <neeraj.laad@gmail.com>
 default-template: simple

--- a/incubator/nodejs/README.md
+++ b/incubator/nodejs/README.md
@@ -2,7 +2,11 @@
 
 The Node.js stack provides a consistent way of developing [Node.js](https://nodejs.org/) applications. As an asynchronous event-driven JavaScript runtime, Node is designed to build scalable network applications.
 
-This stack is based on the `Node.js v10` runtime and allows you to develop new or existing Node.js application using Appsody.
+This stack is based on the `Node.js v10` runtime and allows you to develop new or existing Node.js application using Appsody. 
+
+Additionally, if you are developing an applicaton that includes a HTTP server or a web framework such as Express.js,the stack provides a built-in application performance dashboard using the [appmetrics-dash](https://github.com/runtimetools/appmetrics-dash) module. This makes it easy to see the resource usage and HTTP endpoint performance of your application as it is developed.
+
+The dashboard is only included during development, and is not included in images build using `appsody build`.
 
 ## Templates
 

--- a/incubator/nodejs/image/Dockerfile-stack
+++ b/incubator/nodejs/image/Dockerfile-stack
@@ -9,12 +9,12 @@ ENV APPSODY_WATCH_REGEX="^.*.js$"
 
 ENV APPSODY_INSTALL="npm install"
 
-ENV APPSODY_RUN="npm start"
-ENV APPSODY_RUN_ON_CHANGE="npm start"
+ENV APPSODY_RUN="npm start --node-options --require=appmetrics-dash/attach"
+ENV APPSODY_RUN_ON_CHANGE="npm start --node-options --require=appmetrics-dash/attach"
 ENV APPSODY_RUN_KILL=true
 
-ENV APPSODY_DEBUG="npm start --node-options --inspect=0.0.0.0"
-ENV APPSODY_DEBUG_ON_CHANGE="npm start --node-options --inspect=0.0.0.0"
+ENV APPSODY_DEBUG="npm start --node-options --inspect=0.0.0.0 --require=appmetrics-dash/attach"
+ENV APPSODY_DEBUG_ON_CHANGE="npm start --node-options --inspect=0.0.0.0 --require=appmetrics-dash/attach"
 ENV APPSODY_DEBUG_KILL=true
 
 ENV APPSODY_TEST="npm test"
@@ -22,6 +22,8 @@ ENV APPSODY_TEST_ON_CHANGE=""
 ENV APPSODY_TEST_KILL=false
 
 COPY ./project /project
+RUN cd /project;npm install
+
 WORKDIR /project/user-app
 
 ENV PORT=3000

--- a/incubator/nodejs/image/project/package.json
+++ b/incubator/nodejs/image/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Node.js Stack",
   "license": "Apache-2.0",
   "repository": {

--- a/incubator/nodejs/image/project/package.json
+++ b/incubator/nodejs/image/project/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "nodejs",
+  "version": "0.2.0",
+  "description": "Node.js Stack",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appsody/stacks.git",
+    "directory": "incubator/nodejs/image/project"
+  },
+  "dependencies": {
+  },
+  "devDependencies": {
+    "appmetrics-dash": "^4.1.0"
+  }
+}

--- a/incubator/nodejs/stack.yaml
+++ b/incubator/nodejs/stack.yaml
@@ -1,6 +1,6 @@
 id: nodejs
 name: Node.js application
-version: 0.2.0
+version: 0.2.1
 description: Simple Node.js application
 maintainer: Neeraj Laad <neeraj.laad@gmail.com>
 default-template: simple


### PR DESCRIPTION
The Eclipse Codewind project uses the `appmetrics-dash` NPM module to provide development time application monitoring and performance testing data.

This updates the nodejs and nodejs-express stacks to add appmetrics-dash as a devDependency.

For the nodejs stack, this is done using `attach()`, which means it will only be added if the app provides some form of HTTP server. This is deliberate so that adding the dashboard doesn't prevent applications that are batch jobs etc from exiting.