### PR TITLE
[java-microprofile] Add javametrics as a dev only dependency

### DIFF
--- a/incubator/java-microprofile/README.md
+++ b/incubator/java-microprofile/README.md
@@ -6,6 +6,8 @@ The Java MicroProfile stack uses a parent Maven project object model (POM) to ma
 
 This stack is based on OpenJDK with container-optimizations in OpenJ9 and `Open Liberty v19.0.0.8`. It provides live reloading during development by utilizing `loose application` capabilities.
 
+The stack also provides a in-built application monitoring dashboard based on [javametrics](https://github.com/runtimetools/javametrics). This dashboard is only included during development and is not included in the image built using `appsody build`.
+
 **Note:** Maven is provided by the Appsody stack container, allowing you to build, test, and debug your Java application without installing Maven locally. However, we recommend installing Maven locally for the best IDE experience.
 
 ## Templates
@@ -65,6 +67,7 @@ OpenAPI endpoints:
     - Metrics endpoint: http://localhost:9080/metrics (login as `admin` user with `adminpwd` password)
     - OpenAPI endpoint: http://localhost:9080/openapi
     - Swagger UI endpoint: http://localhost:9080/openapi/ui
+    - Javametrics Dashboard endpoint: http://localhost:9080/javametrics-dash/ (development-time only)
 
 ## License
 

--- a/incubator/java-microprofile/image/Dockerfile-stack
+++ b/incubator/java-microprofile/image/Dockerfile-stack
@@ -38,7 +38,7 @@ ENV APPSODY_DEBUG="JVM_ARGS='-javaagent:resources/javametrics-agent.jar' mvn -B 
 ENV APPSODY_DEBUG_ON_CHANGE="JVM_ARGS='-javaagent:resources/javametrics-agent.jar' mvn -Dmaven.repo.local=/mvn/repository package -DskipTests"
 ENV APPSODY_DEBUG_KILL=false
 
-ENV APPSODY_TEST="JVM_ARGS='-javaagent:resources/javametrics-agent.jar' mvn -B -Dmaven.repo.local=/mvn/repository verify"
+ENV APPSODY_TEST="mvn -B -Dmaven.repo.local=/mvn/repository verify"
 ENV APPSODY_TEST_ON_CHANGE=""
 ENV APPSODY_TEST_KILL=false
 

--- a/incubator/java-microprofile/image/Dockerfile-stack
+++ b/incubator/java-microprofile/image/Dockerfile-stack
@@ -17,6 +17,7 @@ WORKDIR /project/
 RUN mkdir -p /mvn/repository
 RUN mvn -B -Dmaven.repo.local=/mvn/repository -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
 RUN mvn -B -Dmaven.repo.local=/mvn/repository install dependency:go-offline -DskipTests
+RUN mvn -Dmaven.repo.local=/mvn/repository install dependency:go-offline -DskipTests -f pom-dev.xml
 
 WORKDIR /project/user-app
 
@@ -27,17 +28,17 @@ ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/target
 ENV APPSODY_WATCH_REGEX="^.*(.xml|.java|.properties)$"
 
-ENV APPSODY_INSTALL="../validate.sh && mvn -B -Dmaven.repo.local=/mvn/repository install -DskipTests"
+ENV APPSODY_INSTALL="../validate.sh && mvn -B -Dmaven.repo.local=/mvn/repository install -DskipTests && /project/install-dev-deps.sh"
 
-ENV APPSODY_RUN="mvn -B -Dmaven.repo.local=/mvn/repository liberty:run"
-ENV APPSODY_RUN_ON_CHANGE="mvn -Dmaven.repo.local=/mvn/repository package -DskipTests"
+ENV APPSODY_RUN="JVM_ARGS='-javaagent:resources/javametrics-agent.jar' mvn -B -Dmaven.repo.local=/mvn/repository liberty:run"
+ENV APPSODY_RUN_ON_CHANGE="JVM_ARGS='-javaagent:resources/javametrics-agent.jar' mvn -Dmaven.repo.local=/mvn/repository package -DskipTests"
 ENV APPSODY_RUN_KILL=false
 
-ENV APPSODY_DEBUG="mvn -B -Dmaven.repo.local=/mvn/repository liberty:debug"
-ENV APPSODY_DEBUG_ON_CHANGE="mvn -Dmaven.repo.local=/mvn/repository package -DskipTests"
+ENV APPSODY_DEBUG="JVM_ARGS='-javaagent:resources/javametrics-agent.jar' mvn -B -Dmaven.repo.local=/mvn/repository liberty:debug"
+ENV APPSODY_DEBUG_ON_CHANGE="JVM_ARGS='-javaagent:resources/javametrics-agent.jar' mvn -Dmaven.repo.local=/mvn/repository package -DskipTests"
 ENV APPSODY_DEBUG_KILL=false
 
-ENV APPSODY_TEST="mvn -B -Dmaven.repo.local=/mvn/repository verify"
+ENV APPSODY_TEST="JVM_ARGS='-javaagent:resources/javametrics-agent.jar' mvn -B -Dmaven.repo.local=/mvn/repository verify"
 ENV APPSODY_TEST_ON_CHANGE=""
 ENV APPSODY_TEST_KILL=false
 

--- a/incubator/java-microprofile/image/project/install-dev-deps.sh
+++ b/incubator/java-microprofile/image/project/install-dev-deps.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+mvn -Dmaven.repo.local=/mvn/repository dependency:copy-dependencies@copy-dropin dependency:copy-dependencies@copy-resource dependency:copy-dependencies@copy-asm -f /project/pom-dev.xml
+mkdir -p /project/user-app/target/liberty/wlp/usr/servers/defaultServer/configDropins/defaults
+cp /project/server-dev.xml /project/user-app/target/liberty/wlp/usr/servers/defaultServer/configDropins/defaults/server.xml

--- a/incubator/java-microprofile/image/project/pom-dev.xml
+++ b/incubator/java-microprofile/image/project/pom-dev.xml
@@ -1,0 +1,91 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>dev.appsody</groupId>
+    <artifactId>dev-dependencies</artifactId>
+    <version>0.2.0</version>
+    <packaging>jar</packaging>
+
+    <repositories>
+        <repository>
+            <id>localrepository</id>
+            <url>/mvn/repository</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+      <dependency>
+          <groupId>com.ibm.runtimetools</groupId>
+          <artifactId>javametrics-agent</artifactId>
+          <version>[1.2,2.0)</version>
+          <scope>provided</scope>
+      </dependency>
+      <dependency>
+          <groupId>com.ibm.runtimetools</groupId>
+          <artifactId>javametrics-dash</artifactId>
+          <version>[1.2,2.0)</version>
+          <scope>provided</scope>
+          <type>war</type>
+      </dependency>
+      <dependency>
+          <groupId>com.ibm.runtimetools</groupId>
+          <artifactId>javametrics-rest</artifactId>
+          <version>[1.2,2.0)</version>
+          <scope>provided</scope>
+          <type>war</type>
+      </dependency>
+  </dependencies>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.0.1</version>
+          <executions>
+              <execution>
+                  <id>copy-dropin</id>
+                  <phase>package</phase>
+                  <goals>
+                      <goal>copy-dependencies</goal>
+                  </goals>
+                  <configuration>
+                  <stripVersion>true</stripVersion>
+                  <outputDirectory>${project.build.directory}/../user-app/target/liberty/wlp/usr/servers/defaultServer/dropins</outputDirectory>
+                  <includeArtifactIds>javametrics-dash,javametrics-rest</includeArtifactIds>
+              </configuration>
+              </execution>
+              <execution>
+                  <id>copy-resource</id>
+                  <phase>package</phase>
+                  <goals>
+                      <goal>copy-dependencies</goal>
+                  </goals>
+                  <configuration>
+                  <stripVersion>true</stripVersion>
+                  <outputDirectory>${project.build.directory}/../user-app/target/liberty/wlp/usr/servers/defaultServer/resources/</outputDirectory>
+                  <includeArtifactIds>javametrics-agent</includeArtifactIds>
+              </configuration>
+              </execution>
+              <execution>
+                  <id>copy-asm</id>
+                  <phase>package</phase>
+                  <goals>
+                      <goal>copy-dependencies</goal>
+                  </goals>
+                  <configuration>
+                  <outputDirectory>${project.build.directory}/../user-app/target/liberty/wlp/usr/servers/defaultServer/resources/asm</outputDirectory>
+                  <includeGroupIds>org.ow2.asm</includeGroupIds>
+                  <includeArtifactIds>asm,asm-commons</includeArtifactIds>
+              </configuration>
+              </execution>
+          </executions>
+      </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/incubator/java-microprofile/image/project/server-dev.xml
+++ b/incubator/java-microprofile/image/project/server-dev.xml
@@ -1,0 +1,6 @@
+<server>
+    <featureManager>
+        <feature>managedBeans-1.0</feature>
+        <feature>websocket-1.1</feature>
+    </featureManager>
+</server>

--- a/incubator/java-microprofile/stack.yaml
+++ b/incubator/java-microprofile/stack.yaml
@@ -1,5 +1,5 @@
 name: Eclipse MicroProfile®
-version: 0.2.17
+version: 0.2.18
 description: Eclipse MicroProfile on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
This adds Javametrics-dash as a dev only dependency as part of the stack. This both provides developers with a build-in performance view, and enables the Eclipse Codewind IDE project to do application monitoring and performance testing the of the application during development.

The approach to providing the Javametrics dashboard during development only is as follows:
* Provide a pom-dev.xml file that installs the dependencies as installs them into the server which is only run in Dockerfile-stack, and not in the production Dockerfile.
* Provide a server-dev.xml that adds the necessary features that is only copied into the config dropins the Dockerfile-stack, and not in the production Dockerfile.

This pattern can be extended if there's further capabilities that we want to provide only during development.