### PR TITLE
Updating index for java-spring-boot2 v0.3.1

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -28,8 +28,8 @@ projects:
     maintainers:
     - schnabel@us.ibm.com
     urls:
-    - https://github.com/appsody/stacks/releases/download/java-spring-boot2-v0.3.0/incubator.java-spring-boot2.templates.default.tar.gz
-    version: 0.3.0
+    - https://github.com/appsody/stacks/releases/download/java-spring-boot2-v0.3.1/incubator.java-spring-boot2.templates.default.tar.gz
+    version: 0.3.1
   nodejs:
   - created: 2019-06-24T21:00:00+00:00
     description: Node.js Runtime


### PR DESCRIPTION
- Updating index for java-spring-boot2 v0.3.1 (adds index page on default route)