### PR TITLE
Use mvn package instead of compile on change

### DIFF
--- a/incubator/java-microprofile/image/Dockerfile-stack
+++ b/incubator/java-microprofile/image/Dockerfile-stack
@@ -25,7 +25,7 @@ ENV APPSODY_DEPS=/mvn/repository
 ENV APPSODY_INSTALL="mvn -Dmaven.repo.local=/mvn/repository install -DskipTests"
 
 ENV APPSODY_RUN="../validate.sh && mvn -Dmaven.repo.local=/mvn/repository liberty:run"
-ENV APPSODY_RUN_ON_CHANGE="mvn -Dmaven.repo.local=/mvn/repository compile"
+ENV APPSODY_RUN_ON_CHANGE="mvn -Dmaven.repo.local=/mvn/repository package"
 ENV APPSODY_RUN_KILL=false
 
 ENV APPSODY_DEBUG="../validate.sh && mvn -Dmaven.repo.local=/mvn/repository liberty:debug"

--- a/incubator/java-microprofile/image/Dockerfile-stack
+++ b/incubator/java-microprofile/image/Dockerfile-stack
@@ -25,11 +25,11 @@ ENV APPSODY_DEPS=/mvn/repository
 ENV APPSODY_INSTALL="mvn -Dmaven.repo.local=/mvn/repository install -DskipTests"
 
 ENV APPSODY_RUN="../validate.sh && mvn -Dmaven.repo.local=/mvn/repository liberty:run"
-ENV APPSODY_RUN_ON_CHANGE="mvn -Dmaven.repo.local=/mvn/repository package"
+ENV APPSODY_RUN_ON_CHANGE="mvn -Dmaven.repo.local=/mvn/repository package -DskipTests"
 ENV APPSODY_RUN_KILL=false
 
 ENV APPSODY_DEBUG="../validate.sh && mvn -Dmaven.repo.local=/mvn/repository liberty:debug"
-ENV APPSODY_DEBUG_ON_CHANGE="mvn -Dmaven.repo.local=/mvn/repository compile"
+ENV APPSODY_DEBUG_ON_CHANGE="mvn -Dmaven.repo.local=/mvn/repository package -DskipTests"
 ENV APPSODY_DEBUG_KILL=false
 
 ENV APPSODY_TEST="../validate.sh && mvn -Dmaven.repo.local=/mvn/repository verify"


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

- [ ] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #32, Related to #54, etc.
-->
Fixes #
Related to https://github.com/appsody/controller/issues/7

## Modifying an existing stack:

### Description
<!--- Describe your changes in detail -->

I propose using `mvn package` rather than `mvn compile` in the java-microprofile stack ON_CHANGE command. 
The reason is that `package` allows liberty to pick up config changes to server.xml such as creating new endpoints or features. In an obscure case (which we hit testing https://github.com/appsody/controller/issues/7 ) if the liberty server is started with a compile error in one of the endpoints, fixing the compile error and running `mvn compile` does not enable the endpoint but `mvn package` does.

See also https://openliberty.io/guides/getting-started.html#updating-the-server-configuration-without-restarting-the-server

The downside of this is a longer ON_CHANGE command. On my local machine it takes roughly 3 secs to run package vs 1 sec to run compile.