### PR TITLE
kotlin-spring-boot2: adding a Kotlin with Spring Boot 2 stack

### DIFF
--- a/experimental/kotlin-spring-boot2/LICENSE
+++ b/experimental/kotlin-spring-boot2/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/experimental/kotlin-spring-boot2/README.md
+++ b/experimental/kotlin-spring-boot2/README.md
@@ -1,0 +1,54 @@
+# Kotlin Spring® Boot 2 Stack
+
+The Kotlin Spring Boot 2 stack supports the development of [Spring Boot 2](https://spring.io/projects/spring-boot) applications using OpenJDK 8 and OpenJ9 from [AdoptOpenJDK](https://adoptopenjdk.net/), in Kotlin.
+
+The Spring Boot 2 stack uses a parent Maven project object model (POM) to manage dependency versions and provide required capabilities and plugins. Specifically, this stack enables [Spring Boot Actuator](https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-actuator), the Prometheus Micrometer reporter, and OpenTracing support for Spring using a Jaeger tracer.
+
+The [Spring Developer Tools](https://docs.spring.io/spring-boot/docs/current/reference/html/using-boot-devtools.html#using-boot-devtools) module is also included to support automatic restarts and live reloading during development.
+
+**Note:** Maven is provided by the Appsody stack container, allowing you to build, test, and debug your Java application without installing Maven locally. We recommend installing Maven locally for the best IDE experience.
+
+## Templates
+
+Templates are used to create your local project and start your development.
+
+The default template provides a `pom.xml` file that references the parent POM defined by the stack, and a simple Spring Boot application main class that defines a basic [liveness endpoint](#health-checks-readiness-and-liveness), and a set of unit tests that ensure enabled actuator endpoints work properly: `/actuator/health`, `/actuator/metrics`, `/actuator/prometheus`, and `actuator/liveness`.
+
+## Getting Started
+
+1. Create a new folder in your local directory and initialize it using the Appsody CLI, e.g.:
+
+    ```bash
+    mkdir my-project
+    cd my-project
+    appsody init kotlin-spring-boot2
+    ```
+
+    This will initialize a Spring Boot 2 project using the microservice template.
+
+1. Once your project has been initialized you can then run your application using the following command:
+
+    ```bash
+    appsody run
+    ```
+
+    This launches a Docker container that will run your application in the foreground, exposing it on port 8080. The application will be restarted automatically when changes are detected.
+
+1. You should be able to access the following endpoints, as they are exposed by your template application by default:
+
+    - Health endpoint: http://localhost:8080/actuator/health
+    - Liveness endpoint: http://localhost:8080/actuator/liveness
+    - Metrics endpoint: http://localhost:8080/actuator/metrics
+    - Prometheus endpoint: http://localhost:8080/actuator/prometheus
+
+## Health checks, readiness and liveness
+
+Kubernetes defines two integral mechanisms for checking the health of a container:
+
+* A readiness probe is used to indicate whether the process can handle requests (is routable). Kubernetes doesn't route work to a container with a failing readiness probe. A readiness probe should fail if a service hasn't finished initializing, or is otherwise busy, overloaded, or unable to process requests.
+
+* A liveness probe is used to indicate whether the process should be restarted. Kubernetes stops and restarts a container with a failing liveness probe to ensure that Pods in a defunct state are terminated and replaced. A liveness probe should fail if the service is in an irrecoverable state, for example, if an out of memory condition occurs. Simple liveness checks that always return an OK response can identify containers in an inconsistent state, which can happen when process serving requests has crashed but the container is still running.
+
+The Spring Boot 2 Actuator defines an `/actuator/health` endpoint, which returns a {"status": "UP"} payload when all is well. This endpoint is enabled by default, and requires no application code. This actuator works well as a Kubernetes readiness probe, as it automatically includes the status of required resources.
+
+The health endpoint is less useful as a liveness check. In Spring Boot 2, the Actuator framework can be trivially extended with custom endpoints. Your application will include a trivial endpoint to be used as a Kubernetes liveness probe.

--- a/experimental/kotlin-spring-boot2/image/.dockerignore
+++ b/experimental/kotlin-spring-boot2/image/.dockerignore
@@ -1,0 +1,4 @@
+**/target
+**/.git
+**/.gitignore
+**/.vscode

--- a/experimental/kotlin-spring-boot2/image/Dockerfile-stack
+++ b/experimental/kotlin-spring-boot2/image/Dockerfile-stack
@@ -1,0 +1,45 @@
+FROM appsody/java-spring-boot2:0.3
+LABEL maintainer="IBM Java Engineering at IBM Cloud"
+
+RUN apt-get update && apt-get -qq install -y unzip && \
+    cd /usr/lib && \
+    wget -q https://github.com/JetBrains/kotlin/releases/download/v1.3.40/kotlin-compiler-1.3.40.zip && \
+    unzip kotlin-compiler-*.zip && \
+    rm kotlin-compiler-*.zip && \
+    rm -f kotlinc/bin/*.bat
+
+ENV PATH $PATH:/usr/lib/kotlinc/bin
+
+COPY ./project /project
+COPY ./mvn-stack-settings.xml /usr/share/maven/conf/settings.xml
+COPY ./mvn-stack-settings.xml /project/.mvn-stack-settings.xml
+
+WORKDIR /project/user-app
+
+ENV APPSODY_USER_RUN_AS_LOCAL=true
+
+ENV APPSODY_MOUNTS=".:/project/user-app;~/.m2/repository:/mvn/repository"
+ENV APPSODY_DEPS=
+
+ENV APPSODY_WATCH_DIR="/project/user-app/"
+ENV APPSODY_WATCH_IGNORE_DIR=""
+ENV APPSODY_WATCH_REGEX="^.*.kt$"
+
+ENV APPSODY_RUN="/project/kotlin-spring-boot2-build.sh run"
+ENV APPSODY_RUN_ON_CHANGE="/project/kotlin-spring-boot2-build.sh recompile"
+ENV APPSODY_RUN_KILL=false
+
+ENV APPSODY_DEBUG="/project/kotlin-spring-boot2-build.sh debug"
+ENV APPSODY_DEBUG_ON_CHANGE=""
+ENV APPSODY_DEBUG_KILL=false
+
+ENV APPSODY_TEST="/project/kotlin-spring-boot2-build.sh test"
+ENV APPSODY_TEST_ON_CHANGE=""
+ENV APPSODY_TEST_KILL=true
+
+ENV PORT=8080
+
+EXPOSE 8080
+EXPOSE 5005
+EXPOSE 35729
+ENTRYPOINT ["/project/kotlin-spring-boot2-build.sh", "run"]

--- a/experimental/kotlin-spring-boot2/image/mvn-stack-settings.xml
+++ b/experimental/kotlin-spring-boot2/image/mvn-stack-settings.xml
@@ -1,0 +1,15 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <!-- Use this file to customize maven repositories or other proxies that should be 
+       used when building projects: 
+       Defaults: https://maven.apache.org/settings.html
+       Reference: https://maven.apache.org/ref/3.6.1/maven-settings/settings.html
+  -->
+
+  <!-- Repository location in docker image -->
+  <localRepository>/mvn/repository</localRepository>
+
+</settings>

--- a/experimental/kotlin-spring-boot2/image/project/.appsody-init.bat
+++ b/experimental/kotlin-spring-boot2/image/project/.appsody-init.bat
@@ -1,0 +1,3 @@
+if not exist %SystemDrive%%HOMEPATH%\.m2\repository\ (
+  mkdir %SystemDrive%%HOMEPATH%\.m2\repository
+)

--- a/experimental/kotlin-spring-boot2/image/project/.appsody-init.sh
+++ b/experimental/kotlin-spring-boot2/image/project/.appsody-init.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+if [ -n "$TERM" ] && [ "$TERM" != "dumb" ] && [ -x /usr/bin/tput ] && [[ `tput colors` != "0" ]]; then
+  color_prompt="yes"
+else
+  color_prompt=
+fi
+
+if [[ "$color_prompt" == "yes" ]]; then
+      BLUE="\033[0;34m"
+  NO_COLOR="\033[0m"
+else
+        BLUE=""
+  NO_COLOUR=""
+fi
+
+if [ ! -d ~/.m2/repository ]; then
+  echo -e "${BLUE}Creating local maven repository:  ~/.m2/repository${NO_COLOR}"
+  mkdir -p ~/.m2/repository
+fi

--- a/experimental/kotlin-spring-boot2/image/project/.dockerignore
+++ b/experimental/kotlin-spring-boot2/image/project/.dockerignore
@@ -1,0 +1,4 @@
+**/target
+**/.git
+**/.gitignore
+**/.vscode

--- a/experimental/kotlin-spring-boot2/image/project/Dockerfile
+++ b/experimental/kotlin-spring-boot2/image/project/Dockerfile
@@ -1,0 +1,42 @@
+FROM maven:3.6-ibmjava-8 as compile
+LABEL maintainer="IBM Java Engineering at IBM Cloud"
+
+# Ensure up to date / patched OS
+RUN  apt-get -qq update \
+  && apt-get -qq install -y curl wget xmlstarlet \
+  && DEBIAN_FRONTEND=noninteractive apt-get -qq upgrade -y \
+  && apt-get -qq clean \
+  && rm -rf /tmp/* /var/lib/apt/lists/* \
+  && mkdir -p /mvn/repository
+
+RUN apt-get update && apt-get -qq install -y unzip && \
+    cd /usr/lib && \
+    wget -q https://github.com/JetBrains/kotlin/releases/download/v1.3.40/kotlin-compiler-1.3.40.zip && \
+    unzip kotlin-compiler-*.zip && \
+    rm kotlin-compiler-*.zip && \
+    rm -f kotlinc/bin/*.bat
+
+ENV PATH $PATH:/usr/lib/kotlinc/bin
+
+#setup project folder for kotlin build step
+COPY . /project
+COPY ./.mvn-stack-settings.xml /usr/share/maven/conf/settings.xml
+
+WORKDIR /project/user-app
+
+RUN /project/kotlin-spring-boot2-build.sh package
+
+####
+FROM adoptopenjdk:8-jdk-openj9
+
+ARG artifactId=appsody-spring
+ARG version=1.0-SNAPSHOT
+ENV JVM_ARGS=""
+
+LABEL maintainer="IBM Java Engineering at IBM Cloud"
+LABEL org.opencontainers.image.version=${version}
+LABEL org.opencontainers.image.title=${artifactId}
+
+COPY --from=compile /project/user-app/target/app.jar /app.jar
+
+ENTRYPOINT [ "sh", "-c", "java $JVM_ARGS -Djava.security.egd=file:/dev/./urandom -jar /app.jar" ]

--- a/experimental/kotlin-spring-boot2/image/project/appsody-boot2-pom.xml
+++ b/experimental/kotlin-spring-boot2/image/project/appsody-boot2-pom.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>dev.appsody</groupId>
+  <artifactId>spring-boot2-stack</artifactId>
+  <version>0.3.1</version>
+  <packaging>pom</packaging>
+
+  <name>Appsody Spring Boot2 stack</name>
+  <description>Parent POM file for Kabanero project to facilitate usage of Spring Boot on OpenShift.</description>
+  <url>https://appsody.dev</url>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <!-- order of precedence of the artifact’s version is:
+    * The version of the artifact’s direct declaration in project pom
+    * The version of the artifact in the parent project
+    * The version in the imported pom, taking into consideration the order of importing files
+    * dependency mediation
+    * If the same artifact is defined with different versions in 2 imported BOMs,
+      then the version in the BOM file that was declared first will win
+  -->
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.6.RELEASE</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
+
+  <properties>
+    <!-- Required library versions -->
+    <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
+    <opentracing-spring-jaeger-web-starter.version>2.0.0</opentracing-spring-jaeger-web-starter.version>
+
+    <java.version>1.8</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- required dependency versions -->
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- Core -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!--Monitoring -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-reflect</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+    </dependency>
+
+    <!-- Distributed tracing with OpenTracing -->
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+      <version>${opentracing-spring-jaeger-web-starter.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+    <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+    <!-- ensure fixed archive name so multistage build can find app archive -->
+    <finalName>app</finalName>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+        </plugin>
+        <plugin>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${maven-enforcer-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>enforce-banned-dependencies</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <bannedDependencies>
+                    <excludes>
+                      <exclude>org.springframework.boot:spring-boot-starter-web</exclude>
+                    </excludes>
+                    <includes>
+                      <include>org.springframework.boot:spring-boot-starter-web:${spring-boot.version}</include>
+                    </includes>
+                  </bannedDependencies>
+                </rules>
+                <fail>true</fail>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>${maven-clean-plugin.version}</version>
+          <configuration>
+            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+            <filesets>
+              <fileset>
+                <directory>${project.build.outputDirectory}</directory>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+              </fileset>
+            </filesets>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
+        <configuration>
+           <args>
+              <arg>-Xjsr305=strict</arg>
+           </args>
+           <compilerPlugins>
+              <plugin>spring</plugin>
+           </compilerPlugins>
+        </configuration>
+        <dependencies>
+           <dependency>
+              <groupId>org.jetbrains.kotlin</groupId>
+              <artifactId>kotlin-maven-allopen</artifactId>
+              <version>${kotlin.version}</version>
+           </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <!-- Activate Spring developer tools when using appsody -->
+    <profile>
+        <id>dev</id>
+        <activation>
+          <property>
+            <name>env.APPSODY_RUN</name>
+          </property>
+        </activation>
+        <dependencies>
+          <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <optional>true</optional>
+          </dependency>
+        </dependencies>
+    </profile>
+  </profiles>
+</project>

--- a/experimental/kotlin-spring-boot2/image/project/kotlin-spring-boot2-build.sh
+++ b/experimental/kotlin-spring-boot2/image/project/kotlin-spring-boot2-build.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+if [ -n "$TERM" ] && [ "$TERM" != "dumb" ] && [ -x /usr/bin/tput ] && [[ `tput colors` != "0" ]]; then
+  color_prompt="yes"
+else
+  color_prompt=
+fi
+
+if [[ "$color_prompt" == "yes" ]]; then
+      BLUE="\033[0;34m"
+    GREEN="\033[0;32m"
+    WHITE="\033[1;37m"
+      RED="\033[0;31m"
+    YELLOW="\033[0;33m"
+  NO_COLOR="\033[0m"
+else
+        BLUE=""
+      GREEN=""
+      WHITE=""
+        RED=""
+  NO_COLOUR=""
+fi
+
+note() {
+  echo -e "${BLUE}$@${NO_COLOR}"
+}
+warn() {
+  echo -e "${YELLOW}$@${NO_COLOR}"
+}
+error() {
+  echo -e "${RED}$@${NO_COLOR}"
+}
+
+run_mvn () {
+  echo -e "${GREEN}> mvn $@${NO_COLOR}"
+  mvn "$@"
+}
+
+version() {
+  if [ ! -f $1 ]; then
+    error "$1 does not exist."
+    exit 1
+  fi
+
+  # get version from specified POM
+  xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t \
+     -o "export GROUP_ID=" -v "/x:project/x:groupId" -n \
+     -o "export ARTIFACT_ID=" -v "/x:project/x:artifactId" -n \
+     -o "export VERSION=" -v "/x:project/x:version" \
+     $1
+}
+
+common() {
+  # workaround: exit with error if repository does not exist
+  if [ ! -d /mvn/repository ]; then
+    error "Could not find local Maven repository
+
+    Create a .m2/repository directory in your home directory. For example:
+    * linux:   mkdir -p ~/.m2/repository
+    * windows: mkdir %SystemDrive%%HOMEPATH%\.m2\repository
+    "
+    exit 1
+  fi
+
+  # Get parent pom information (appsody-boot2-pom.xml)
+  eval $(version /project/appsody-boot2-pom.xml)
+
+  if ! $(mvn -N dependency:get -q -o -Dartifact=${GROUP_ID}:${ARTIFACT_ID}:${VERSION} -Dpackaging=pom >/dev/null)
+  then
+    # Install parent pom
+    note "Installing parent ${GROUP_ID}:${ARTIFACT_ID}:${VERSION}"
+    run_mvn install -q -f /project/appsody-boot2-pom.xml
+  fi
+
+  local p_groupId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:parent/x:groupId" pom.xml)
+  local p_artifactId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:parent/x:artifactId" pom.xml)
+  local p_version=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:parent/x:version" pom.xml)
+
+  # Require parent in pom.xml
+  if [ "${p_groupId}" != "${GROUP_ID}" ] || [ "${p_artifactId}" != "${ARTIFACT_ID}" ]; then
+    error "Project is missing required parent:
+
+    <parent>
+      <groupId>${GROUP_ID}</groupId>
+      <artifactId>${ARTIFACT_ID}</artifactId>
+      <version>${VERSION}</version>
+      <relativePath/>
+    </parent>
+    "
+    exit 1
+  fi
+
+  if [ "${p_version}" != "${VERSION}" ]; then
+    major=$(echo ${VERSION} | cut -d'.' -f1)
+    ((next=major+1))
+
+    note "Updating parent version"
+    run_mvn -q versions:update-parent "-DparentVersion=[${major},${next})"
+  fi
+
+  unset GROUP_ID ARTIFACT_ID VERSION
+}
+
+recompile() {
+  note "Compile project in the foreground"
+  run_mvn compile
+}
+
+package() {
+  note "Package project in the foreground"
+  run_mvn clean package verify
+}
+
+debug() {
+  note "Build and debug project in the foreground"
+  run_mvn spring-boot:run -Dspring-boot.run.jvmArguments='-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005'
+}
+
+run() {
+  note "Build and run project in the foreground"
+  run_mvn clean -Dmaven.test.skip=true spring-boot:run
+}
+
+test() {
+  note "Test project in the foreground"
+  run_mvn package test
+}
+
+#set the action, default to fail text if none passed.
+ACTION=
+if [ $# -ge 1 ]; then
+  ACTION=$1
+  shift
+fi
+
+case "${ACTION}" in
+  recompile)
+    recompile
+  ;;
+  package)
+    common
+    package
+  ;;
+  debug)
+    common
+    debug
+  ;;
+  run)
+    common
+    run
+  ;;
+  test)
+    common
+    test
+  ;;
+  *)
+    error "Unexpected script usage, expected one of recompile, package, debug, run, test"
+  ;;
+esac

--- a/experimental/kotlin-spring-boot2/stack.yaml
+++ b/experimental/kotlin-spring-boot2/stack.yaml
@@ -1,0 +1,7 @@
+id: kotlin-spring-boot2
+name: Kotlin application using Spring Boot 2
+version: 0.1.0
+description: Spring Boot 2 project with health and metrics actuators enabled. Metrics support is provided by Micrometer, and is configured with Prometheus support.
+maintainer: Pushkar N Kulkarni<pushkar.nk@in.ibm.com>
+default-template: default
+license: Apache-2.0

--- a/experimental/kotlin-spring-boot2/templates/sample/.appsody-config.yaml
+++ b/experimental/kotlin-spring-boot2/templates/sample/.appsody-config.yaml
@@ -1,0 +1,1 @@
+stack: pushkarnk/kotlin-spring-boot2:0.1

--- a/experimental/kotlin-spring-boot2/templates/sample/.gitignore
+++ b/experimental/kotlin-spring-boot2/templates/sample/.gitignore
@@ -1,0 +1,27 @@
+/target/*
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+/build/
+
+### VS Code ###
+.vscode/

--- a/experimental/kotlin-spring-boot2/templates/sample/pom.xml
+++ b/experimental/kotlin-spring-boot2/templates/sample/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent><!--required parent POM-->
+    <groupId>dev.appsody</groupId>
+    <artifactId>spring-boot2-stack</artifactId>
+    <version>0.3.1</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>dev.appsody</groupId>
+  <artifactId>application</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <!-- versions will come from the parent pom (and included bom):
+    mvn dependency:tree
+    mvn dependency:display-ancestors
+    mvn help:effective-pom | grep '\.version>'
+    -->
+
+  <dependencies>
+    <!-- From parent:
+      org.springframework.boot:spring-boot-starter
+      org.springframework.boot:spring-boot-starter-actuator
+      org.springframework.boot:spring-boot-starter-test
+     -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/experimental/kotlin-spring-boot2/templates/sample/src/main/kotlin/com/example/hello/Application.kt
+++ b/experimental/kotlin-spring-boot2/templates/sample/src/main/kotlin/com/example/hello/Application.kt
@@ -1,0 +1,24 @@
+package com.example.hello
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.stereotype.Component;
+
+@SpringBootApplication
+class HelloWorldApp {
+
+    @Endpoint(id = "liveness")
+    @Component
+    class Liveness {
+        @ReadOperation
+	public fun testLiveness(): String {
+            return "{\"status\":\"UP\"}";
+	}
+    }
+}
+
+fun main(args: Array<String>) {
+    runApplication<HelloWorldApp>(*args)
+}

--- a/experimental/kotlin-spring-boot2/templates/sample/src/main/kotlin/com/example/hello/Controller.kt
+++ b/experimental/kotlin-spring-boot2/templates/sample/src/main/kotlin/com/example/hello/Controller.kt
@@ -1,0 +1,14 @@
+package com.example.hello
+
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.ui.Model
+import org.springframework.ui.set
+import org.springframework.web.bind.annotation.GetMapping
+
+@RestController
+class Controller {
+    @GetMapping("/hello")
+    fun hello(): String {
+        return "Hello from Appsody!"
+    }
+}

--- a/experimental/kotlin-spring-boot2/templates/sample/src/main/resources/application.properties
+++ b/experimental/kotlin-spring-boot2/templates/sample/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+#enable the actuator endpoints for health, metrics, and prometheus.
+management.endpoints.web.exposure.include=health,metrics,prometheus,liveness

--- a/experimental/kotlin-spring-boot2/templates/sample/src/main/resources/public/index.html
+++ b/experimental/kotlin-spring-boot2/templates/sample/src/main/resources/public/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Hello from Appsody!</title>
+  </head>
+  <body>
+    <h3>Hello from Appsody!</h3>
+    <p>Next steps with Spring Boot 2:
+      <ul>
+        <li><a target="_blank" rel="noopener" href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot Reference Guide</a></li>
+        <li><a target="_blank" rel="noopener" href="https://spring.io/guides">Spring Guides</a></li>
+        <li><a target="_blank" rel="noopener" href="/actuator">Spring Boot Actuator endpoints</a>:
+          <ul>
+            <li><a target="_blank" rel="noopener" href="/actuator/health">Health</a></li>
+            <li><a target="_blank" rel="noopener" href="/actuator/liveness">Appsody Liveness</a></li>
+            <li><a target="_blank" rel="noopener" href="/actuator/metrics">Metrics</a></li>
+            <li><a target="_blank" rel="noopener" href="/actuator/prometheus">Prometheus</a></li>
+          </ul>
+        </li>
+      </ul>
+    </p>
+  </body>
+</html>

--- a/experimental/kotlin-spring-boot2/templates/sample/src/test/kotlin/com/example/hello/tests/MainTests.kt
+++ b/experimental/kotlin-spring-boot2/templates/sample/src/test/kotlin/com/example/hello/tests/MainTests.kt
@@ -1,0 +1,55 @@
+package com.example.hello.tests
+
+import org.assertj.core.api.Assertions.*
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.test.context.junit4.SpringRunner
+
+@RunWith(SpringRunner::class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class MainTests {
+
+    @Autowired
+    lateinit var restTemplate: TestRestTemplate
+
+    @Test
+    fun testHealthEndpoint() {
+        val result = restTemplate.getForEntity("/actuator/health", String::class.java)
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body).contains("\"status\":\"UP\"")
+    }
+
+    @Test
+    fun testLivenessEndpoint() {
+        val result = restTemplate.getForEntity("/actuator/health", String::class.java)
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body).contains("\"status\":\"UP\"")    
+    }
+
+    @Test
+    fun testPrometheusEndpoint() {
+        val result = restTemplate.getForEntity("/actuator/prometheus", String::class.java)
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(result.body).contains("# TYPE jvm_buffer_count_buffers gauge")
+    }
+
+    @Test
+    fun testMetricsEndpoint() {
+        testLivenessEndpoint()
+
+        @SuppressWarnings("rawtypes")
+        val entity = restTemplate.getForEntity("/actuator/metrics", Map::class.java)
+        assertThat(entity.statusCode).isEqualTo(HttpStatus.OK)
+
+        @Suppress("UNCHECKED_CAST")
+        val values: ArrayList<*> = (entity.body?.get("names") as? ArrayList<String>) ?: ArrayList<String>()
+        assertThat(values).contains("jvm.buffer.count")
+    }
+}


### PR DESCRIPTION
This is a refinement of #76 

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).

### Contributing a new stack:

- Describe how application dependencies are managed:
This PR relates to Kotlin support with Spring Boot 2. Just like the `java-spring-boot2` stack the dependency management is done using Maven's parent object model (POM).

- Explain how Appsody file watcher is utilised:
The `APPSODY_WATCH_REGEX` is, for now, set only for `.kt` files. This triggers a recompile whenever a Kotlin source file is modified.

- Describe other Appsody environment variables defined by the stack image:
This defines only those environment vars that are defined by `java-spring-boot2`.

- Describe any limitations and known issues:
This stack has a structure that is identical to `java-spring-boot2`. If `appsody` provided a way to inherit code from other stacks, we could be reducing on the LOC here.  