### PR TITLE
Updated stacks to use APPSODY_PREP instead of APPSODY_INSTALL

### DIFF
--- a/experimental/nodejs-functions/image/Dockerfile-stack
+++ b/experimental/nodejs-functions/image/Dockerfile-stack
@@ -6,7 +6,7 @@ ENV APPSODY_DEPS=/project/user-app/functions/node_modules
 ENV APPSODY_WATCH_DIR=/project/user-app/functions
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/functions/node_modules
 
-ENV APPSODY_INSTALL="npm install --prefix user-app/functions && npm audit fix --prefix user-app/functions"
+ENV APPSODY_PREP="npm install --prefix user-app/functions && npm audit fix --prefix user-app/functions"
 
 ENV APPSODY_TEST="npm test && npm test --prefix user-app/functions"
 

--- a/incubator/java-microprofile/image/Dockerfile-stack
+++ b/incubator/java-microprofile/image/Dockerfile-stack
@@ -22,7 +22,7 @@ ENV APPSODY_DEPS=/mvn/repository
 # ENV APPSODY_WATCH_IGNORE_DIR=
 # ENV APPSODY_WATCH_REGEX=""
 
-ENV APPSODY_INSTALL="mvn -Dmaven.repo.local=/mvn/repository install -DskipTests"
+ENV APPSODY_PREP="mvn -Dmaven.repo.local=/mvn/repository install -DskipTests"
 
 ENV APPSODY_RUN="../validate.sh && mvn -Dmaven.repo.local=/mvn/repository liberty:run"
 ENV APPSODY_RUN_ON_CHANGE="mvn -Dmaven.repo.local=/mvn/repository package -DskipTests"

--- a/incubator/nodejs-express/image/Dockerfile-stack
+++ b/incubator/nodejs-express/image/Dockerfile-stack
@@ -7,7 +7,7 @@ ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/node_modules
 ENV APPSODY_WATCH_REGEX="^.*.js$"
 
-ENV APPSODY_INSTALL="npm install --prefix user-app && npm audit fix --prefix user-app"
+ENV APPSODY_PREP="npm install --prefix user-app && npm audit fix --prefix user-app"
 
 ENV APPSODY_RUN="npm start"
 ENV APPSODY_RUN_ON_CHANGE="npm start"

--- a/incubator/nodejs/image/Dockerfile-stack
+++ b/incubator/nodejs/image/Dockerfile-stack
@@ -7,7 +7,7 @@ ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/node_modules
 ENV APPSODY_WATCH_REGEX="^.*.js$"
 
-ENV APPSODY_INSTALL="npm install && npm audit fix"
+ENV APPSODY_PREP="npm install && npm audit fix"
 
 ENV APPSODY_RUN="npm start --node-options --require=appmetrics-dash/attach"
 ENV APPSODY_RUN_ON_CHANGE="npm start --node-options --require=appmetrics-dash/attach"

--- a/incubator/swift/image/Dockerfile-stack
+++ b/incubator/swift/image/Dockerfile-stack
@@ -9,7 +9,7 @@ ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/.build
 ENV APPSODY_WATCH_REGEX="^.*.swift$"
 
-ENV APPSODY_INSTALL="swift build"
+ENV APPSODY_PREP="swift build"
 
 ENV APPSODY_RUN="swift run"
 ENV APPSODY_RUN_ON_CHANGE="swift run"


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->
Update stacks to use APPSODY_PREP instead of APPSODY_INSTALL environment variable. 

### Related Issues:
Fixes: https://github.com/appsody/stacks/issues/89