### PR TITLE
stacks-build: fix hardcoded directory for local build

### DIFF
--- a/ci/list.sh
+++ b/ci/list.sh
@@ -44,7 +44,7 @@ else
             do
                 if [ -f $stack_exists ]
                 then
-                    var=`echo $stack_exists | sed 's/.*stacks\///'`
+                    var=`echo ${stack_exists#"$base_dir/"}`
                     repo_stack=`awk '{split($1, a, "/*"); print a[1]"/"a[2]}' <<< $var`
                     if [ $TRAVIS_TAG ] && [[ $repo_stack != */$stack_id ]]
                     then


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->
The problem arose because no stacks are detected when the `stacks` folder was named anything else. stacks is currently a hardcoded value in the `list.sh` script. implementing a change that subtracts the base directory from the pwd for the stack.

The full set of stacks in the incubator, stable and experimental directories should now be found.
ie: from my working system.

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
Fixes: https://github.com/appsody/stacks/issues/153