### PR TITLE
nodejs: bumped version of appmetrics-dash

### DIFF
--- a/experimental/nodejs-functions/stack.yaml
+++ b/experimental/nodejs-functions/stack.yaml
@@ -1,5 +1,5 @@
 name: Node.js Functions
-version: 0.1.0
+version: 0.1.1
 description: Serverless runtime for Node.js functions
 license: Apache-2.0
 maintainers:

--- a/incubator/nodejs-express/image/project/package.json
+++ b/incubator/nodejs-express/image/project/package.json
@@ -21,7 +21,6 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "~6.1.0",
-    "request": "^2.88.0",
-    "appmetrics-dash": "^5.0.0"
+    "request": "^2.88.0"
   }
 }

--- a/incubator/nodejs-express/image/project/package.json
+++ b/incubator/nodejs-express/image/project/package.json
@@ -22,6 +22,6 @@
     "chai": "^4.2.0",
     "mocha": "~6.1.0",
     "request": "^2.88.0",
-    "appmetrics-dash": "^4.1.0"
+    "appmetrics-dash": "^5.0.0"
   }
 }

--- a/incubator/nodejs-express/stack.yaml
+++ b/incubator/nodejs-express/stack.yaml
@@ -1,5 +1,5 @@
 name: Node.js Express
-version: 0.2.2
+version: 0.2.3
 description: Express web framework for Node.js
 license: Apache-2.0
 maintainers:

--- a/incubator/nodejs/image/project/package.json
+++ b/incubator/nodejs/image/project/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
   },
   "devDependencies": {
-    "appmetrics-dash": "^4.1.0"
+    "appmetrics-dash": "^5.0.0"
   }
 }

--- a/incubator/nodejs/image/project/package.json
+++ b/incubator/nodejs/image/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "Node.js Stack",
   "license": "Apache-2.0",
   "repository": {

--- a/incubator/nodejs/stack.yaml
+++ b/incubator/nodejs/stack.yaml
@@ -1,5 +1,5 @@
 name: Node.js
-version: 0.2.2
+version: 0.2.3
 description: Runtime for Node.js applications
 license: Apache-2.0
 maintainers:


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

Updated version of appmetrics-dash for nodejs and nodejs-express stacks. Reduces amount of deprecated declarations when building stacks from build.sh script.
