### PR TITLE
nodejs-express: adding appmetrics-dash as a dependancy

### DIFF
--- a/incubator/nodejs-express/image/project/package.json
+++ b/incubator/nodejs-express/image/project/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "~6.1.0",
-    "request": "^2.88.0"
+    "request": "^2.88.0",
+    "appmetrics-dash": "^5.0.0"
   }
 }


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->
Node modules don't get inherited from the nodejs image. Instead the nodejs-express replaces the node_modules folder with its dependancies

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->