### PR TITLE
nodejs-express: appmetrics-dash depends on 3.0.0 on prometheus

### DIFF
--- a/incubator/nodejs-express/image/project/package.json
+++ b/incubator/nodejs-express/image/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-express",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "Node.js Express Stack",
   "license": "Apache-2.0",
   "repository": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@cloudnative/health-connect": "^2.0.0",
-    "appmetrics-prometheus": "^2.0.0",
+    "appmetrics-prometheus": "^3.0.0",
     "express": "~4.16.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->
appmetrics-dash depends on 3.0.0 version of appmetrics-prometheus

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->