### PR TITLE
swift: add support for swift-slim production images

### DIFF
--- a/incubator/swift/README.md
+++ b/incubator/swift/README.md
@@ -8,7 +8,7 @@ This stack is based on the `Swift 5.0` runtime and allows you to develop new or 
 
 Templates are used to create your local project and start your development. When initializing your project you will be provided with the default template project. This template provides a simple application that prints "Hello World".
 
-## Getting Started
+## Getting Started for a new Project
 
 1. Create a new folder in your local directory and initialize it using the Appsody CLI, e.g.:
 
@@ -19,7 +19,7 @@ Templates are used to create your local project and start your development. When
     ```
     This will initialize a Swift project using the default template.
 
-1. After your project has been initialized you can then run your application using the following command:
+2. After your project has been initialized you can then run your application using the following command:
 
     ```bash
     appsody run
@@ -36,3 +36,33 @@ Templates are used to create your local project and start your development. When
     ```
 
 **NOTE:** Currently the `appsody deploy` command only works for deploying web applications.
+
+## Enabling an existing Project
+
+The Swift stack can be used with an existing server-side Swift project in order to provide an interative containerized development and test environment, and to "cloud package" it into an optimized production Docker container.
+
+You can enable an existing project as follows:
+
+1. Go to you project directory, e.g.:
+
+    ```bash
+    cd my-project
+    ```
+    
+2. Initialise your an Appsody project with the Swift stack, but without a template:
+
+    ```bash
+    appsody init swift --no-template
+    ```
+
+3. After your project has been initialized you can then run your application using the following command:
+
+    ```bash
+    appsody run
+    ```
+
+    This launches a Docker container that continuously re-builds and re-runs your project. It also exposes port 8080, to allow you to bring your own web application and use it with this stack.
+
+    You can continue to edit the application in your preferred IDE (VSCode or other) and your changes will be reflected in the running container within a few seconds.
+
+3. You should see your application run, with logs writtent to the console.

--- a/incubator/swift/README.md
+++ b/incubator/swift/README.md
@@ -39,7 +39,7 @@ Templates are used to create your local project and start your development. When
 
 ## Enabling an existing Project
 
-The Swift stack can be used with an existing server-side Swift project in order to provide an interative containerized development and test environment, and to "cloud package" it into an optimized production Docker container.
+The Swift stack can be used with an existing server-side Swift project in order to provide an iterative containerized development and test environment, and to "cloud package" it into an optimized production Docker container.
 
 You can enable an existing project as follows:
 
@@ -49,7 +49,7 @@ You can enable an existing project as follows:
     cd my-project
     ```
     
-2. Initialise your an Appsody project with the Swift stack, but without a template:
+2. Initialize your Appsody project with the Swift stack, but without a template:
 
     ```bash
     appsody init swift --no-template
@@ -65,4 +65,4 @@ You can enable an existing project as follows:
 
     You can continue to edit the application in your preferred IDE (VSCode or other) and your changes will be reflected in the running container within a few seconds.
 
-3. You should see your application run, with logs writtent to the console.
+3. You should see your application run, with logs written to the console.

--- a/incubator/swift/image/project/Dockerfile
+++ b/incubator/swift/image/project/Dockerfile
@@ -1,5 +1,5 @@
 # Install the app dependencies
-FROM swift:5.0
+FROM swift:5.0 as builder
 
 # Install OS updates
 RUN apt-get update \
@@ -10,6 +10,24 @@ RUN apt-get update \
 # Install user-app dependencies
 WORKDIR "/project/user-app"
 COPY ./user-app ./
-RUN swift build -c release
+RUN echo "#!/bin/bash" > run.sh
+RUN swift build -c release > output.txt
+RUN cat output.txt | awk 'END {print $NF}' >> run.sh
+RUN chmod 755 run.sh
 
-CMD ["swift", "run"]
+FROM swift:5.0-slim
+
+# Install OS updates
+RUN apt-get update \
+ && apt-get install -y libcurl4-openssl-dev libssl-dev \
+ && apt-get clean \
+ && echo 'Finished installing dependencies'
+
+WORKDIR "/project"
+COPY --from=builder /project/user-app/.build /project/.build
+COPY --from=builder /project/user-app/run.sh /project
+
+ENV PORT 8080
+EXPOSE 8080
+
+CMD ["./run.sh"]

--- a/incubator/swift/image/project/Dockerfile
+++ b/incubator/swift/image/project/Dockerfile
@@ -10,10 +10,10 @@ RUN apt-get update \
 # Install user-app dependencies
 WORKDIR "/project/user-app"
 COPY ./user-app ./
-RUN echo "#!/bin/bash" > run.sh
-RUN swift build -c release > output.txt
-RUN cat output.txt | awk 'END {print $NF}' >> run.sh
-RUN chmod 755 run.sh
+RUN echo "#!/bin/bash" > run.sh \
+ && swift build -c release > output.txt \
+ && cat output.txt | awk 'END {print $NF}' >> run.sh \
+ && chmod 755 run.sh
 
 FROM swift:5.0-slim
 

--- a/incubator/swift/stack.yaml
+++ b/incubator/swift/stack.yaml
@@ -1,5 +1,5 @@
 name: Swift
-version: 0.1.0
+version: 0.1.1
 description: Runtime for Swift applications
 license: Apache-2.0
 maintainers:


### PR DESCRIPTION
### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [X] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [X] Updated the stack version in `stack.yaml`

This adds support for multi-stage docker builds for the final "production" build that's invoked using `appsody build`.