### PR TITLE
stacks: fixed errors when importing projects to Eclipse

### DIFF
--- a/experimental/nodejs-functions/templates/simple/.vscode/launch.json
+++ b/experimental/nodejs-functions/templates/simple/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/experimental/nodejs-functions/templates/simple/.vscode/tasks.json
+++ b/experimental/nodejs-functions/templates/simple/.vscode/tasks.json
@@ -1,6 +1,4 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
     "version": "2.0.0",
     "tasks": [
         {
@@ -44,6 +42,6 @@
             "command": "appsody stop",
             "group": "build",
             "problemMatcher": []
-        },
+        }
     ]
 }

--- a/incubator/nodejs-express/templates/simple/.vscode/launch.json
+++ b/incubator/nodejs-express/templates/simple/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/incubator/nodejs-express/templates/simple/.vscode/tasks.json
+++ b/incubator/nodejs-express/templates/simple/.vscode/tasks.json
@@ -1,6 +1,4 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
     "version": "2.0.0",
     "tasks": [
         {
@@ -44,6 +42,6 @@
             "command": "appsody stop",
             "group": "build",
             "problemMatcher": []
-        },
+        }
     ]
 }

--- a/incubator/nodejs-express/templates/skaffold/.vscode/launch.json
+++ b/incubator/nodejs-express/templates/skaffold/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/incubator/nodejs-express/templates/skaffold/.vscode/tasks.json
+++ b/incubator/nodejs-express/templates/skaffold/.vscode/tasks.json
@@ -1,6 +1,4 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
     "version": "2.0.0",
     "tasks": [
         {
@@ -44,6 +42,6 @@
             "command": "appsody stop",
             "group": "build",
             "problemMatcher": []
-        },
+        }
     ]
 }

--- a/incubator/nodejs/templates/simple/.vscode/launch.json
+++ b/incubator/nodejs/templates/simple/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/incubator/nodejs/templates/simple/.vscode/tasks.json
+++ b/incubator/nodejs/templates/simple/.vscode/tasks.json
@@ -1,6 +1,4 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
     "version": "2.0.0",
     "tasks": [
         {
@@ -44,6 +42,6 @@
             "command": "appsody stop",
             "group": "build",
             "problemMatcher": []
-        },
+        }
     ]
 }

--- a/incubator/swift/templates/simple/.vscode/tasks.json
+++ b/incubator/swift/templates/simple/.vscode/tasks.json
@@ -1,6 +1,4 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
     "version": "2.0.0",
     "tasks": [
         {
@@ -44,6 +42,6 @@
             "command": "appsody stop",
             "group": "build",
             "problemMatcher": []
-        },
+        }
     ]
 }


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->
Fixed errors for the `launch.json` and `tasks.json` files when importing an appsody project into Eclipse. Removed comments in both files and the trailing ',' in` tasks.json`

### Related Issues:
Fixes: #126