### PR TITLE
build: limit create_codewind_index.sh

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -17,4 +17,6 @@ fi
 . $base_dir/ci/package.sh $base_dir
 . $base_dir/ci/test.sh $base_dir
 
-python $base_dir/ci/create_codewind_index.py $base_dir
+if [ "$CODEWIND_JSON" == "true" ]; then
+    python $base_dir/ci/create_codewind_index.py $base_dir
+fi

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -17,6 +17,6 @@ fi
 . $base_dir/ci/package.sh $base_dir
 . $base_dir/ci/test.sh $base_dir
 
-if [ "$CODEWIND_JSON" == "true" ]; then
+if [ "$CODEWIND_INDEX" == "true" ]; then
     python $base_dir/ci/create_codewind_index.py $base_dir
 fi

--- a/ci/env.sh
+++ b/ci/env.sh
@@ -4,6 +4,7 @@ set -e
 # You can set the following environment variables to specify your docker credentials or docker registry: DOCKER_PASSWORD, DOCKER_USERNAME and DOCKER_REGISTRY
 
 # If you would like to generate the Codewind index, set the environment variable CODEWIND_INDEX to 'true'
+# You will need to download the PyYaml module to generate this file
 
 #this is the default list of repos that we need to build index for
 if [ -z "$REPO_LIST" ]; then

--- a/ci/env.sh
+++ b/ci/env.sh
@@ -3,6 +3,8 @@ set -e
 
 # You can set the following environment variables to specify your docker credentials or docker registry: DOCKER_PASSWORD, DOCKER_USERNAME and DOCKER_REGISTRY
 
+# If you would like to generate the Codewind index, set the environment variable CODEWIND_INDEX to 'true'
+
 #this is the default list of repos that we need to build index for
 if [ -z "$REPO_LIST" ]; then
     export REPO_LIST="experimental incubator stable"


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

Added environment variable `CODEWIND_JSON`. The create_codewind_index.sh script only runs if `CODEWIND_JSON` is set to true. 

### Related Issues:
Fixes: #179 