### PR TITLE
[Swift] Add apt-get zlib1g-dev for use by Vapor apps

### DIFF
--- a/incubator/swift/image/Dockerfile-stack
+++ b/incubator/swift/image/Dockerfile-stack
@@ -1,6 +1,10 @@
 FROM swift:5.0
 
-RUN apt-get update && apt-get install -y libcurl4-openssl-dev libssl-dev
+RUN apt-get update \
+ && apt-get dist-upgrade -y \
+ && apt-get install -y zlib1g-dev libcurl4-openssl-dev libssl-dev \
+ && apt-get clean \
+ && echo 'Finished installing dependencies'
 
 ENV APPSODY_MOUNTS=/:/project/user-app
 ENV APPSODY_DEPS=/project/user-app/.build

--- a/incubator/swift/image/Dockerfile-stack
+++ b/incubator/swift/image/Dockerfile-stack
@@ -1,7 +1,6 @@
 FROM swift:5.0
 
 RUN apt-get update \
- && apt-get dist-upgrade -y \
  && apt-get install -y zlib1g-dev libcurl4-openssl-dev libssl-dev \
  && apt-get clean \
  && echo 'Finished installing dependencies'

--- a/incubator/swift/image/project/Dockerfile
+++ b/incubator/swift/image/project/Dockerfile
@@ -3,7 +3,6 @@ FROM swift:5.0 as builder
 
 # Install OS updates
 RUN apt-get update \
- && apt-get dist-upgrade -y \
  && apt-get install -y zlib1g-dev libcurl4-openssl-dev libssl-dev \
  && apt-get clean \
  && echo 'Finished installing dependencies'
@@ -20,7 +19,6 @@ FROM swift:5.0-slim
 
 # Install OS updates
 RUN apt-get update \
- && apt-get dist-upgrade -y \
  && apt-get clean \
  && echo 'Finished installing dependencies'
 

--- a/incubator/swift/image/project/Dockerfile
+++ b/incubator/swift/image/project/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
 WORKDIR "/project/user-app"
 COPY ./user-app ./
 RUN echo "#!/bin/bash" > run.sh \
- && swift build -c release > output.txt \
+ && swift build -c release | tee output.txt \
  && cat output.txt | awk 'END {print $NF}' >> run.sh \
  && chmod 755 run.sh
 

--- a/incubator/swift/image/project/Dockerfile
+++ b/incubator/swift/image/project/Dockerfile
@@ -3,7 +3,8 @@ FROM swift:5.0 as builder
 
 # Install OS updates
 RUN apt-get update \
- && apt-get install -y libcurl4-openssl-dev libssl-dev \
+ && apt-get dist-upgrade -y \
+ && apt-get install -y zlib1g-dev libcurl4-openssl-dev libssl-dev \
  && apt-get clean \
  && echo 'Finished installing dependencies'
 
@@ -19,7 +20,8 @@ FROM swift:5.0-slim
 
 # Install OS updates
 RUN apt-get update \
- && apt-get install -y libcurl4-openssl-dev libssl-dev \
+ && apt-get dist-upgrade -y \
+ && apt-get install -y zlib1g-dev libcurl4-openssl-dev libssl-dev \
  && apt-get clean \
  && echo 'Finished installing dependencies'
 

--- a/incubator/swift/image/project/Dockerfile
+++ b/incubator/swift/image/project/Dockerfile
@@ -21,7 +21,6 @@ FROM swift:5.0-slim
 # Install OS updates
 RUN apt-get update \
  && apt-get dist-upgrade -y \
- && apt-get install -y zlib1g-dev libcurl4-openssl-dev libssl-dev \
  && apt-get clean \
  && echo 'Finished installing dependencies'
 

--- a/incubator/swift/stack.yaml
+++ b/incubator/swift/stack.yaml
@@ -1,5 +1,5 @@
 name: Swift
-version: 0.1.1
+version: 0.1.2
 description: Runtime for Swift applications
 license: Apache-2.0
 maintainers:


### PR DESCRIPTION
### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [X] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [X] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

This adds `apt-get install -y zlib1g-dev` to `Dockerfile-stack` for development and to the production `Dockerfile` for use by Vapor based apps.