### PR TITLE
Nginx image for index + tar.gz; pass additional parameters to docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /ci/assets
 /ci/package
 /ci/build
+/ci/nginx/docker-compose.override.yml
 **/.DS_Store
 **/node_modules
 **/*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ script:
   - pyenv global 3.6
   - pip3 install pyyaml
   - ./ci/prefetch.sh
-  - . ./ci/build.sh .
+  - . ./ci/build.sh
 
 # note before_deploy will run before each deploy provider
 before_deploy:
-  - . ./ci/release.sh .
+  - . ./ci/release.sh
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ services:
 script:
   - pyenv global 3.6
   - pip3 install pyyaml
+  - ./ci/prefetch.sh
   - . ./ci/build.sh .
 
 # note before_deploy will run before each deploy provider

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,31 +1,35 @@
 #!/bin/bash
 set -e
 
-if [ -z "$1" ]
+# setup environment
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/env.sh
+
+if [ $# -gt 0 ]
 then
-  echo "One argument is required and must be the base directory of the repository."
-  exit 1
+    # ignore the old basedir argument
+    dir=$(cd "$1" && pwd)
+    if [ -f $dir/RELEASE.md ]
+    then
+        shift
+    fi
 fi
 
-base_dir="$(cd "$1" && pwd)"
-
-if [ ! -z "$2" ]
+# Allow multiple stacks to be selected
+if [ $# -gt 0 ]
 then
-  export STACKS_LIST="$2"
+  export STACKS_LIST="$@"
+  echo "STACKS_LIST=$STACKS_LIST"
 fi
-
-. $base_dir/ci/env.sh $base_dir
 
 if [ -z "$STACKS_LIST" ]
 then
-  . $base_dir/ci/list.sh $base_dir
-else
-  echo "STACKS_LIST=$STACKS_LIST"
+  . $script_dir/list.sh
 fi
-. $base_dir/ci/lint.sh $base_dir
-. $base_dir/ci/package.sh $base_dir
-. $base_dir/ci/test.sh $base_dir
+
+. $script_dir/lint.sh
+. $script_dir/package.sh
+. $script_dir/test.sh
 
 if [ "$CODEWIND_INDEX" == "true" ]; then
-  python3 $base_dir/ci/create_codewind_index.py $base_dir
+  python3 $script_dir/create_codewind_index.py
 fi

--- a/ci/env.sh
+++ b/ci/env.sh
@@ -1,16 +1,13 @@
 #!/bin/bash
 set -e
 
-# first argument of this script must be the base dir of the repository
-if [ -z "$1" ]
-then
-    echo "One argument is required and must be the base directory of the repository."
-    exit 1
-fi
+export script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+export base_dir=$(cd "${script_dir}/.." && pwd)
+export assets_dir="${script_dir}/assets"
+export build_dir="${script_dir}/build"
 
-base_dir="$(cd "$1" && pwd)"
-
-# ENVIRONMENT VARIABLES (shown with defaults)
+mkdir -p $assets_dir
+mkdir -p $build_dir
 
 # Docker credentials for publishing images:
 # export DOCKER_USERNAME
@@ -44,9 +41,9 @@ base_dir="$(cd "$1" && pwd)"
 
 
 #expose an extension point for running before main 'env' processing
-if [ -f $base_dir/ci/ext/pre_env.sh ]
+if [ -f $script_dir/ext/pre_env.sh ]
 then
-    . $base_dir/ci/ext/pre_env.sh
+    . $script_dir/ext/pre_env.sh
 fi
 
 #this is the default list of repos that we need to build index for
@@ -77,7 +74,7 @@ then
     then
         # Find git organization for the current branch
         git_remote=$(git for-each-ref --format='%(upstream:remotename)' "$(git symbolic-ref -q HEAD)")
-	git_remote=${git_remote:-origin}
+        git_remote=${git_remote:-origin}
 
         git_remote_url=$(git remote get-url $git_remote)
         git_remote_url=${git_remote_url:-https://github.com/appsody/stacks.git}
@@ -117,7 +114,7 @@ then
 fi
 
 #expose an extension point for running after main 'env' processing
-if [ -f $base_dir/ci/ext/post_env.sh ]
+if [ -f $script_dir/ext/post_env.sh ]
 then
-    . $base_dir/ci/ext/post_env.sh
+    . $script_dir/ext/post_env.sh
 fi

--- a/ci/env.sh
+++ b/ci/env.sh
@@ -10,10 +10,38 @@ fi
 
 base_dir="$(cd "$1" && pwd)"
 
-# You can set the following environment variables to specify your docker credentials or docker registry: DOCKER_PASSWORD, DOCKER_USERNAME and DOCKER_REGISTRY
+# ENVIRONMENT VARIABLES (shown with defaults)
 
-# If you would like to generate the Codewind index, set the environment variable CODEWIND_INDEX to 'true'
-# You will need to download the PyYaml module to generate this file
+# Docker credentials for publishing images:
+# export DOCKER_USERNAME
+# export DOCKER_PASSWORD
+# export DOCKER_REGISTRY
+
+# Organization for Docker images
+# export DOCKERHUB_ORG=appsody
+
+# List of apposdy repositories to build indexes for
+# export REPO_LIST="experimental incubator stable"
+
+# git information (determined from current branch if unspecified)
+# export GIT_BRANCH
+# export GIT_ORG_REPO=appsody/stacks
+
+# External/remote URL for downloading git released assets
+# export RELEASE_URL=https://github.com/$GIT_ORG_REPO/releases/download
+
+# Create template archive if it is missing
+# export PACKAGE_WHEN_MISSING=true
+
+# Version or snapshot identifier for appsody-index (ci/package.sh)
+# export INDEX_VERSION=SNAPSHOT
+
+# Base nginx image for appsody-index (ci/nginx/Dockerfile)
+# export NGINX_IMAGE=nginx:stable-alpine
+
+# Build the Codewind index when the value is 'true' (requires PyYaml)
+# export CODEWIND_INDEX
+
 
 #expose an extension point for running before main 'env' processing
 if [ -f $base_dir/ci/ext/pre_env.sh ]
@@ -27,13 +55,65 @@ if [ -z "$REPO_LIST" ]; then
 fi
 
 # dockerhub org for publishing stack
-if [ -z $DOCKERHUB_ORG ]; then
+if [ -z $DOCKERHUB_ORG ]
+then
     export DOCKERHUB_ORG=appsody
 fi
 
-# url for downloading released assets
-if [ -z $RELEASE_URL ]; then
-    export RELEASE_URL="https://github.com/$TRAVIS_REPO_SLUG/releases/download"
+if [ -z $GIT_BRANCH ]
+then
+    if [ -z $TRAVIS_BRANCH ]
+    then
+        export GIT_BRANCH=$(git for-each-ref --format='%(refname:lstrip=2)' "$(git symbolic-ref -q HEAD)")
+    else
+        export GIT_BRANCH=${TRAVIS_BRANCH}
+    fi
+fi
+
+# find github repository slug
+if [ -z $GIT_ORG_REPO ]
+then
+    if [ -z "$TRAVIS_REPO_SLUG" ]
+    then
+        # Find git organization for the current branch
+        git_remote=$(git for-each-ref --format='%(upstream:remotename)' "$(git symbolic-ref -q HEAD)")
+	git_remote=${git_remote:-origin}
+
+        git_remote_url=$(git remote get-url $git_remote)
+        git_remote_url=${git_remote_url:-https://github.com/appsody/stacks.git}
+        git_remote_url=${git_remote_url#*:}
+
+        git_repo=$(basename $git_remote_url .git)
+        git_repo=${git_repo:-stacks}
+
+        git_org=$(basename $(dirname $git_remote_url))
+        git_org=${git_org:-appsody}
+
+        export GIT_ORG_REPO=$git_org/$git_repo
+    else
+        export GIT_ORG_REPO=$TRAVIS_REPO_SLUG
+    fi
+fi
+
+if [ -z "$RELEASE_URL" ]
+then
+    # url for downloading git released assets
+    export RELEASE_URL="https://github.com/$GIT_ORG_REPO/releases/download"
+fi
+
+if [ -z "$PACKAGE_WHEN_MISSING" ] 
+then
+    export PACKAGE_WHEN_MISSING=true
+fi
+
+if [ -z $INDEX_VERSION ]
+then
+    if [ -z $TRAVIS_BUILD_NUMBER ]
+    then
+        export INDEX_VERSION=SNAPSHOT
+    else
+        export INDEX_VERSION=${TRAVIS_BUILD_NUMBER}
+    fi
 fi
 
 #expose an extension point for running after main 'env' processing

--- a/ci/env.sh
+++ b/ci/env.sh
@@ -30,6 +30,9 @@ mkdir -p $build_dir
 # Create template archive if it is missing
 # export PACKAGE_WHEN_MISSING=true
 
+# Name of appsody-index image (ci/package.sh)
+# export INDEX_NAME=appsody-index
+
 # Version or snapshot identifier for appsody-index (ci/package.sh)
 # export INDEX_VERSION=SNAPSHOT
 
@@ -98,9 +101,14 @@ then
     export RELEASE_URL="https://github.com/$GIT_ORG_REPO/releases/download"
 fi
 
-if [ -z "$PACKAGE_WHEN_MISSING" ] 
+if [ -z "$PACKAGE_WHEN_MISSING" ]
 then
     export PACKAGE_WHEN_MISSING=true
+fi
+
+if [ -z $INDEX_NAME ]
+then
+    export INDEX_NAME=appsody-index
 fi
 
 if [ -z $INDEX_VERSION ]

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -1,18 +1,13 @@
 #!/bin/bash
 set -e
 
-if [ -z "$1" ]
-then
-    echo "One argument is required and must be the base directory of the repository."
-    exit 1
-fi
-
-base_dir="$(cd "$1" && pwd)"
+# setup environment
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/env.sh
 
 #expose an extension point for running before main 'lint' processing
-if [ -f $base_dir/ci/ext/pre_lint.sh ]
+if [ -f $script_dir/ext/pre_lint.sh ]
 then
-    . $base_dir/ci/ext/pre_lint.sh $base_dir
+    . $script_dir/ext/pre_lint.sh $base_dir
 fi
 
 error=0
@@ -117,7 +112,7 @@ then
 fi
 
 #expose an extension point for running after main 'lint' processing
-if [ -f $base_dir/ci/ext/post_lint.sh ]
+if [ -f $script_dir/ext/post_lint.sh ]
 then
-    . $base_dir/ci/ext/post_lint.sh $base_dir
+    . $script_dir/ext/post_lint.sh $base_dir
 fi

--- a/ci/list.sh
+++ b/ci/list.sh
@@ -1,21 +1,13 @@
 #!/bin/bash
 set -e
 
-# first argument of this script must be the base dir of the repository
-if [ -z "$1" ]
-then
-    echo "One argument is required and must be the base directory of the repository."
-    exit 1
-fi
-
-base_dir="$(cd "$1" && pwd)"
-
-. $base_dir/ci/env.sh $base_dir
+# setup environment
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/env.sh
 
 # expose an extension point for running beforer main 'list' processing
-if [ -f $base_dir/ci/ext/pre_list.sh ]
+if [ -f $script_dir/ext/pre_list.sh ]
 then
-    . $base_dir/ci/ext/pre_list.sh $base_dir
+    . $script_dir/ext/pre_list.sh $base_dir
 fi
 
 # check if running on travis pull request or not
@@ -71,7 +63,7 @@ export STACKS_LIST=${STACKS_LIST[@]}
 echo "STACKS_LIST=$STACKS_LIST"
 
 # expose an extension point for running after main 'list' processing
-if [ -f $base_dir/ci/ext/post_list.sh ]
+if [ -f $script_dir/ext/post_list.sh ]
 then
-    . $base_dir/ci/ext/post_list.sh $base_dir 
+    . $script_dir/ext/post_list.sh $base_dir 
 fi

--- a/ci/nginx/Dockerfile
+++ b/ci/nginx/Dockerfile
@@ -1,0 +1,13 @@
+ARG NGINX_IMAGE=nginx:stable-alpine
+FROM $NGINX_IMAGE
+
+COPY nginx/nginx.conf  /etc/nginx/nginx.conf
+COPY nginx/startup.sh  /opt/startup.sh
+COPY assets            /opt/www/public
+COPY build/index-src   /opt/index-src
+
+RUN rm /opt/www/public/*-local.yaml
+
+EXPOSE 8080
+
+ENTRYPOINT ["/opt/startup.sh"]

--- a/ci/nginx/docker-compose.yml
+++ b/ci/nginx/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '2'
+services:
+  index:
+    build:
+      context: ..
+      dockerfile: nginx/Dockerfile
+    image: "appsody/appsody-index"
+    container_name: "appsody-index"
+    ports:
+      - "8008:8080"
+    environment:
+      - EXTERNAL_URL=http://localhost:8008/
+
+  verify:
+    image: "appsody/appsody-index"
+    container_name: "appsody-verify"
+    entrypoint: ""
+    command: sh -c "/opt/startup.sh; cat /opt/www/public/*.yaml"
+    environment:
+      - EXTERNAL_URL=http://localhost:8008/
+      - DRY_RUN=true

--- a/ci/nginx/nginx.conf
+++ b/ci/nginx/nginx.conf
@@ -1,0 +1,50 @@
+user nginx;
+worker_processes  1;
+daemon off;
+
+# Default nginx image symlinks:
+# ln -sf /dev/stdout /var/log/nginx/access.log
+# ln -sf /dev/stderr /var/log/nginx/error.log
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+  worker_connections  1024;
+}
+
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  sendfile       off;
+  tcp_nopush     on;
+  tcp_nodelay    on;
+
+  gzip  on;
+  gzip_min_length 50;
+  gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon;
+
+  keepalive_timeout 65;
+
+  server {
+    listen    8080;
+
+    access_log  /var/log/nginx/access.log;
+
+    error_page  404    /404.html;
+
+    server_name localhost;
+
+    location / {
+      root  /opt/www/public;
+      autoindex on;
+    }
+
+    location /health {
+      access_log  off;
+      error_log   off;
+      return 200  'ok';
+    }
+  }
+}

--- a/ci/nginx/startup.sh
+++ b/ci/nginx/startup.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+cp -R /opt/index-src/* /opt/www/public
+
+# Replace the resource paths in index yaml files to match the specified external URL
+find /opt/www/public -name '*.yaml' -exec sed -i -e "s|{{EXTERNAL_URL}}|${EXTERNAL_URL%/}|" {} \;
+
+if [ -z "${DRY_RUN}" ]
+then
+    exec nginx
+fi

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -17,8 +17,10 @@ assets_dir=$base_dir/ci/assets
 build_dir=$base_dir/ci/build
 
 mkdir -p $build_dir/index-src
+# remember images to push
+> $build_dir/image_list
 
-#expose an extension point for running before main 'package' processing
+# expose an extension point for running before main 'package' processing
 if [ -f $base_dir/ci/ext/pre_package.sh ]
 then
     . $base_dir/ci/ext/pre_package.sh $base_dir
@@ -88,6 +90,11 @@ do
                             -t $DOCKERHUB_ORG/$stack_id:$stack_version_major.$stack_version_minor \
                             -t $DOCKERHUB_ORG/$stack_id:$stack_version_major.$stack_version_minor.$stack_version_patch \
                             -f $stack_dir/image/Dockerfile-stack $stack_dir/image
+
+                        echo "$DOCKERHUB_ORG/$stack_id" >> $build_dir/image_list
+                        echo "$DOCKERHUB_ORG/$stack_id:$stack_version_major" >> $build_dir/image_list
+                        echo "$DOCKERHUB_ORG/$stack_id:$stack_version_major.$stack_version_minor" >> $build_dir/image_list
+                        echo "$DOCKERHUB_ORG/$stack_id:$stack_version_major.$stack_version_minor.$stack_version_patch" >> $build_dir/image_list
                     fi
                 else
                     echo -e "\n- SKIPPING stack image: $repo_name/$stack_id"
@@ -207,3 +214,6 @@ docker build $nginx_arg \
  -t $DOCKERHUB_ORG/appsody-index:${GIT_BRANCH}-${INDEX_VERSION} \
  -f $base_dir/ci/nginx/Dockerfile $base_dir/ci
 
+echo "$DOCKERHUB_ORG/appsody-index" >> $build_dir/image_list
+echo "$DOCKERHUB_ORG/appsody-index:${GIT_BRANCH}" >> $build_dir/image_list
+echo "$DOCKERHUB_ORG/appsody-index:${GIT_BRANCH}-${INDEX_VERSION}" >> $build_dir/image_list

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -14,8 +14,9 @@ base_dir="$(cd "$1" && pwd)"
 
 # directory to store assets for test or release
 assets_dir=$base_dir/ci/assets
+build_dir=$base_dir/ci/build
 
-mkdir -p $assets_dir
+mkdir -p $build_dir/index-src
 
 #expose an extension point for running before main 'package' processing
 if [ -f $base_dir/ci/ext/pre_package.sh ]
@@ -31,14 +32,18 @@ do
     then
         echo -e "\nProcessing repo: $repo_name"
 
+        # versioned stack directory for per-stack release
         index_file=$assets_dir/$repo_name-index.yaml
+
+        # flat index used by static appsody-index and local test repo
+        index_src=$build_dir/index-src/$repo_name-index.yaml
         index_file_local=$assets_dir/$repo_name-index-local.yaml
+
+        echo "apiVersion: v2" > $index_src
+        echo "stacks:" >> $index_src
 
         echo "apiVersion: v2" > $index_file
         echo "stacks:" >> $index_file
-
-        echo "apiVersion: v2" > $index_file_local
-        echo "stacks:" >> $index_file_local
 
         # iterate over each stack
         for stack in $repo_dir/*/stack.yaml
@@ -48,6 +53,9 @@ do
             then
                 stack_id=$(basename $stack_dir)
                 stack_version=$(awk '/^version *:/ { gsub("version:","",$NF); gsub("\"","",$NF); print $NF}' $stack)
+                stack_version_major=`echo $stack_version | cut -d. -f1`
+                stack_version_minor=`echo $stack_version | cut -d. -f2`
+                stack_version_patch=`echo $stack_version | cut -d. -f3`
 
                 # check if the stack needs to be built
                 build=false
@@ -62,26 +70,33 @@ do
                 if [ $build = true ]
                 then
                     echo -e "\n- BUILDING stack: $repo_name/$stack_id"
-                    stack_version_major=`echo $stack_version | cut -d. -f1`
-                    stack_version_minor=`echo $stack_version | cut -d. -f2`
-                    stack_version_patch=`echo $stack_version | cut -d. -f3`
 
                     if [ -d $stack_dir/image ]
                     then
-                        docker build -t $DOCKERHUB_ORG/$stack_id \
+                        docker build \
+                            --build-arg GIT_ORG_REPO=$GIT_ORG_REPO \
+                            --build-arg DOCKERHUB_ORG=$DOCKERHUB_ORG \
+                            --build-arg STACK_ID=$stack_id \
+                            --build-arg MAJOR_VERSION=$stack_version_major \
+                            --build-arg MINOR_VERSION=$stack_version_minor \
+                            --build-arg PATCH_VERSION=$stack_version_patch \
+                            --label "org.opencontainers.image.created=$(date +%Y-%m-%dT%H:%M:%S%z)" \
+                            --label "org.opencontainers.image.version=${stack_version}" \
+                            --label "org.opencontainers.image.revision=$(git log -1 --pretty=%H)" \
+                            -t $DOCKERHUB_ORG/$stack_id \
                             -t $DOCKERHUB_ORG/$stack_id:$stack_version_major \
                             -t $DOCKERHUB_ORG/$stack_id:$stack_version_major.$stack_version_minor \
                             -t $DOCKERHUB_ORG/$stack_id:$stack_version_major.$stack_version_minor.$stack_version_patch \
                             -f $stack_dir/image/Dockerfile-stack $stack_dir/image
                     fi
-
-                    echo "  - id: $stack_id" >> $index_file_local
-                    sed 's/^/    /' $stack >> $index_file_local
-                    [ -n "$(tail -c1 $index_file_local)" ] && echo >> $index_file_local
-                    echo "    templates:" >> $index_file_local
                 else
-                    echo -e "\n- SKIPPING stack: $repo_name/$stack_id"
+                    echo -e "\n- SKIPPING stack image: $repo_name/$stack_id"
                 fi
+
+                echo "  - id: $stack_id" >> $index_src
+                sed 's/^/    /' $stack >> $index_src
+                [ -n "$(tail -c1 $index_src)" ] && echo >> $index_src
+                echo "    templates:" >> $index_src
 
                 echo "  - id: $stack_id" >> $index_file
                 sed 's/^/    /' $stack >> $index_file
@@ -93,8 +108,16 @@ do
                     if [ -d $template_dir ]
                     then
                         template_id=$(basename $template_dir)
-                        template_archive=$repo_name.$stack_id.templates.$template_id.tar.gz
+                        old_archive=$repo_name.$stack_id.templates.$template_id.tar.gz
+                        versioned_archive=$repo_name.$stack_id.v$stack_version.templates.$template_id.tar.gz
 
+                        # build archive if it doesn't exist
+                        if [ "$PACKAGE_WHEN_MISSING" = "true" ] && [ ! -f $assets_dir/$old_archive ] && [ ! -f $assets_dir/$versioned_archive ]
+                        then
+                            build=true
+                        fi
+
+                        # build template archive; include version in the file name
                         if [ $build = true ]
                         then
                             if [ $stack_version_major -gt 0 ]
@@ -103,24 +126,66 @@ do
                             else
                                 echo "stack: "$DOCKERHUB_ORG/$stack_id:$stack_version_major.$stack_version_minor > $template_dir/.appsody-config.yaml
                             fi
-                            # build template archives
-                            tar -cz -f $assets_dir/$template_archive -C $template_dir .
-                            rm $template_dir/.appsody-config.yaml
-                            echo -e "--- Created template archive: $template_archive"
 
-                            echo "      - id: $template_id" >> $index_file_local
-                            echo "        url: file://$assets_dir/$template_archive" >> $index_file_local
+                            tar -cz -f $assets_dir/$versioned_archive -C $template_dir .
+                            rm $template_dir/.appsody-config.yaml
+                            echo -e "--- Created template archive: $versioned_archive"
                         fi
 
-                        echo "      - id: $template_id" >> $index_file
-                        echo "        url: $RELEASE_URL/$stack_id-v$stack_version/$template_archive" >> $index_file
+                        # Update index yaml based on archive file name (prefer versioned archives)
+                        if [ -f $assets_dir/$versioned_archive ]
+                        then
+                            echo "      - id: $template_id" >> $index_src
+                            echo "        url: {{EXTERNAL_URL}}/$versioned_archive" >> $index_src
+
+                            echo "      - id: $template_id" >> $index_file
+                            echo "        url: $RELEASE_URL/$stack_id-v$stack_version/$versioned_archive" >> $index_file
+                        elif [ -f $assets_dir/$old_archive ]
+                        then
+                            # If an archive exists with no version in the name, 
+                            # check for a prefetch script that can verify it
+                            # matches this stack. This helps ensure that the new
+                            # stack image
+                            if [ -f $build_dir/prefetch-${stack_id}-${template_id} ]
+                            then
+                                result=$($build_dir/prefetch-${stack_id}-${template_id} ${stack_version})
+                                if [ "$result" == "ok" ]
+                                then
+				    echo "template ok"
+				else
+                                    if [ "$result" == "nomatch" ]
+                                    then
+                                        >&2 echo "WARNING: checksum for $old_archive doesn't match."
+                                        >&2 echo "         The archive contents don't match what was fetched."
+                                        >&2 echo "         Pre-fetched checksum is in ${build_dir}/prefetch-${stack_id}-${template_id}"
+                                    else
+                                        >&2 echo "WARNING: Version mismatch using $template_id for ${stack_id}-v${stack_version}."
+                                        >&2 echo "         Pre-fetched archive built for ${stack_id}-v${result}."
+                                    fi
+                                fi
+                            fi
+
+                            echo "      - id: $template_id" >> $index_src
+                            echo "        url: {{EXTERNAL_URL}}/$old_archive" >> $index_src
+
+                            echo "      - id: $template_id" >> $index_file
+                            echo "        url: $RELEASE_URL/$stack_id-v$stack_version/$old_archive" >> $index_file
+                        else
+                            >&2 echo "ERROR: could not find an archive for $stack_id/$template_id:" 
+                            >&2 echo "       $versioned_archive not found." 
+                            >&2 echo "       $old_archive not found." 
+                        fi
                     fi
                 done
             fi
         done
+
+        # Resolve external URL for local / github release
+        sed -e "s|{{EXTERNAL_URL}}|file://$assets_dir|" $index_src > $index_file_local
     else
         echo "SKIPPING: $repo_dir"
     fi
+
 done
 
 #expose an extension point for running after main 'package' processing
@@ -128,3 +193,17 @@ if [ -f $base_dir/ci/ext/post_package.sh ]
 then
     . $base_dir/ci/ext/post_package.sh $base_dir
 fi
+
+# create appsody-index from contents of assets directory after post-processing
+nginx_arg=
+if [ -n "$NGINX_IMAGE" ]
+then
+    nginx_arg="--build-arg NGINX_IMAGE=$NGINX_IMAGE"
+fi
+
+docker build $nginx_arg \
+ -t $DOCKERHUB_ORG/appsody-index \
+ -t $DOCKERHUB_ORG/appsody-index:${GIT_BRANCH} \
+ -t $DOCKERHUB_ORG/appsody-index:${GIT_BRANCH}-${INDEX_VERSION} \
+ -f $base_dir/ci/nginx/Dockerfile $base_dir/ci
+

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -138,7 +138,7 @@ do
                             echo "        url: $RELEASE_URL/$stack_id-v$stack_version/$versioned_archive" >> $index_file
                         elif [ -f $assets_dir/$old_archive ]
                         then
-                            # If an archive exists with no version in the name, 
+                            # If an archive exists with no version in the name,
                             # check for a prefetch script that can verify it
                             # matches this stack. This helps ensure that the new
                             # stack image
@@ -167,9 +167,9 @@ do
                             echo "      - id: $template_id" >> $index_file
                             echo "        url: $RELEASE_URL/$stack_id-v$stack_version/$old_archive" >> $index_file
                         else
-                            >&2 echo "ERROR: could not find an archive for $stack_id/$template_id:" 
-                            >&2 echo "       $versioned_archive not found." 
-                            >&2 echo "       $old_archive not found." 
+                            >&2 echo "ERROR: could not find an archive for $stack_id/$template_id:"
+                            >&2 echo "       $versioned_archive not found."
+                            >&2 echo "       $old_archive not found."
                         fi
                     fi
                 done
@@ -198,11 +198,11 @@ then
 fi
 
 docker build $nginx_arg \
- -t $DOCKERHUB_ORG/appsody-index \
- -t $DOCKERHUB_ORG/appsody-index:${GIT_BRANCH} \
- -t $DOCKERHUB_ORG/appsody-index:${GIT_BRANCH}-${INDEX_VERSION} \
+ -t $DOCKERHUB_ORG/$INDEX_NAME \
+ -t $DOCKERHUB_ORG/$INDEX_NAME:${GIT_BRANCH} \
+ -t $DOCKERHUB_ORG/$INDEX_NAME:${GIT_BRANCH}-${INDEX_VERSION} \
  -f $script_dir/nginx/Dockerfile $script_dir
 
-echo "$DOCKERHUB_ORG/appsody-index" >> $build_dir/image_list
-echo "$DOCKERHUB_ORG/appsody-index:${GIT_BRANCH}" >> $build_dir/image_list
-echo "$DOCKERHUB_ORG/appsody-index:${GIT_BRANCH}-${INDEX_VERSION}" >> $build_dir/image_list
+echo "$DOCKERHUB_ORG/$INDEX_NAME" >> $build_dir/image_list
+echo "$DOCKERHUB_ORG/$INDEX_NAME:${GIT_BRANCH}" >> $build_dir/image_list
+echo "$DOCKERHUB_ORG/$INDEX_NAME:${GIT_BRANCH}-${INDEX_VERSION}" >> $build_dir/image_list

--- a/ci/prefetch.sh
+++ b/ci/prefetch.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# If provided with a URL for an existing index.yaml file, pre-fetch
+# all referenced template archives.
+#
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+assets_dir=${PWD}/assets
+build_dir=${PWD}/build
+
+mkdir -p $assets_dir
+mkdir -p $build_dir
+
+create="1>/dev/null echo"
+verify="1>/dev/null echo"
+if which md5sum > /dev/null
+then
+    create="md5sum -b"
+    verify="md5sum --status -c -"
+elif which shasum > /dev/null
+then
+    create="shasum -b"
+    verify="shasum --status -c -"
+fi
+
+cd $assets_dir
+if [ -n "${PREFETCH_INDEX_YAML}" ]
+then
+    for url in ${PREFETCH_INDEX_YAML}
+    do
+        echo "== $url"
+        index=$(curl -s -L ${url})
+        for x in $(echo "$index" | grep 'url:' )
+        do
+            if [ $x != 'url:' ]
+            then
+                echo "   $x"
+                curl -s -L -O $x
+                filename=$(basename $x)
+                if ! [[ "$filename" =~  v[0-9]+\.[0-9]+\.[0-9]+ ]]
+                then
+                    # the stack version is in the directory name
+                    release=$(basename $(dirname $x))
+                    split=$(echo $release | awk '{split($0,a,"-v"); print a[1],a[2]}')
+                    declare -a stack=($split)
+
+                    # The template id is in the filename: incubator.nodejs-loopback.templates.scaffold.tar.gz
+                    template_id=$(echo $filename | sed -E 's|.*templates\.(.*)\.tar\.gz|\1|')
+
+                    # Create a script that can compare a pre-fetched template version
+                    # to the current stack version (read from stack.yaml), e.g.:
+                    # ./ci/assets/prefetch-stack_id-template_id 0.3.2
+                    echo '#!/bin/bash
+
+cd "'${assets_dir}'"
+# Fetched from '${url}' on '$(date)'
+# '${x}'
+checksum="'$($create $filename)'"
+if echo "$checksum" | '$verify'
+then
+    if [ "$1" == "'${stack[1]}'" ]
+    then
+        echo ok
+    else
+        echo "'${stack[1]}'"
+    fi
+else
+    echo nomatch
+fi
+' > ${build_dir}/prefetch-"${stack[0]}-${template_id}"
+                    chmod +x ${build_dir}/prefetch-"${stack[0]}-${template_id}"
+                fi
+            fi
+        done
+    done
+fi
+

--- a/ci/prefetch.sh
+++ b/ci/prefetch.sh
@@ -3,12 +3,9 @@
 # If provided with a URL for an existing index.yaml file, pre-fetch
 # all referenced template archives.
 #
-cd "$( dirname "${BASH_SOURCE[0]}" )"
-assets_dir=${PWD}/assets
-build_dir=${PWD}/build
 
-mkdir -p $assets_dir
-mkdir -p $build_dir
+# setup environment
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/env.sh
 
 create="1>/dev/null echo"
 verify="1>/dev/null echo"
@@ -48,7 +45,7 @@ then
 
                     # Create a script that can compare a pre-fetched template version
                     # to the current stack version (read from stack.yaml), e.g.:
-                    # ./ci/assets/prefetch-stack_id-template_id 0.3.2
+                    # ./ci/build/prefetch-stack_id-template_id 0.3.2
                     echo '#!/bin/bash
 
 cd "'${assets_dir}'"

--- a/ci/release.sh
+++ b/ci/release.sh
@@ -1,28 +1,17 @@
 #!/bin/bash
 set -e
 
-# first argument of this script must be the base dir of the repository
-if [ -z "$1" ]
-then
-    echo "One argument is required and must be the base directory of the repository."
-    exit 1
-fi
-
-base_dir="$(cd "$1" && pwd)"
-
-. $base_dir/ci/env.sh $base_dir
+# setup environment
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/env.sh
 
 # directory to store assets for test or release
-assets_dir=$base_dir/ci/assets
-build_dir=$base_dir/ci/build
-release_dir=$base_dir/ci/release
-
+release_dir=$script_dir/release
 mkdir -p $release_dir
 
 # expose an extension point for running before main 'release' processing
-if [ -f $base_dir/ci/ext/pre_release.sh ]
+if [ -f $script_dir/ext/pre_release.sh ]
 then
-    . $base_dir/ci/ext/pre_release.sh $base_dir
+    . $script_dir/ext/pre_release.sh $base_dir
 fi
 
 # iterate over each asset
@@ -62,7 +51,7 @@ else
 fi
 
 # expose an extension point for running after main 'release' processing
-if [ -f $base_dir/ci/ext/post_release.sh ]
+if [ -f $script_dir/ext/post_release.sh ]
 then
-    . $base_dir/ci/ext/post_release.sh $base_dir
+    . $script_dir/ext/post_release.sh $base_dir
 fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,27 +1,20 @@
 #!/bin/bash
 set -e
 
-if [ -z "$1" ]
-then
-    echo "One argument is required and must be the base directory of the repository."
-    exit 1
-fi
-
-base_dir="$(cd "$1" && pwd)"
+# setup environment
+. $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/env.sh
 
 # expose an extension point for running before main 'test' processing
-if [ -f $base_dir/ci/ext/pre_test.sh ]
+if [ -f $script_dir/ext/pre_test.sh ]
 then
-    . $base_dir/ci/ext/pre_test.sh $base_dir
+    . $script_dir/ext/pre_test.sh $base_dir
 fi
-
-. $base_dir/ci/env.sh $base_dir
 
 echo -e "\nNo tests implemented yet"
 
 # expose an extension point for running after main 'test' processing
-if [ -f $base_dir/ci/ext/post_test.sh ]
+if [ -f $script_dir/ext/post_test.sh ]
 then
-    . $base_dir/ci/ext/post_test.sh $base_dir
+    . $script_dir/ext/post_test.sh $base_dir
 fi
 


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).
N/A

### Changes

This updates release packaging to also create a nginx docker image containing the index.yaml files and associated tar.gz. This docker image can be used in environments where git release links won't work (e.g. protected by SAML), and other binary repositories aren't desired.

The `ci/nginx` directory, contains a Dockerfile and nginx.conf file to create an nginx server image (`appsody-index`) that can serve static index and template resources. A `docker-compose.yml` file is also present to make the contents of this image easier to test and verify. Use a `docker-compose.override.yml` file to replace the `{{EXTERNAL_URL}}` value if necessary for local testing. The nginx container can be added to your local appsody repository.

    $ cd ci/nginx
    $ docker-compose up verify        # dump index contents
    $ docker-compose up -d index   # start nginx locally on port 8008
    $ appsody repo add nginx http://localhost:8008/incubator-index.yaml 

`ci/package.sh` generates two index files:

* one for stack-based releases that use URLs like this: 

    {{RELEASE_URL}}/swift-v0.1.4/incubator.swift.templates.simple.tar.gz

*  another in `ci/assets/index-src` that looks like this (implying a flat archive structure), which is used both for local testing, and by the (kabanero-like) appsody-index: 

    {{EXTERNAL_URL}}/incubator.java-spring-boot2.v0.3.6.templates.default.tar.gz

`{{EXTERNAL_URL}}` is resolved to the associated environment variable value when the appsody-index container starts. `./ci/package.sh` replaces that string with the file url for the assets directory when creating the local test repository index.

### Packaging templates

A new script `./ci/prefetch.sh` has been added. If the `PREFETCH_INDEX_YAML` environment variable has been defined, it will download each specified yaml,and then download referenced templates to pre-populate `./ci/assets/`. If the downloaded file does not contain a version, a small  `./ci/assets/prefetch-<stack_id>-<template_id>` script is generated that can be used to compare the version of the stack the template was generated for with the version of the stack in the current repository (which is being used to generate new indexes).

    $ export PREFETCH_INDEX_YAML="https://github.com/appsody/stacks/releases/download/swift-v0.1.4/experimental-index.yaml https://github.com/appsody/stacks/releases/download/swift-v0.1.4/stable-index.yaml https://github.com/appsody/stacks/releases/download/swift-v0.1.4/incubator-index.yaml"
    $ ./ci/prefetch.sh
    $ ./ci/assets/prefetch-java-microprofile-default 1.3.4

./ci/package.sh has been updated to deal with existing template archives with and without the version in the filename.  Any template archive created by the script includes the version in the filename.

### Scenario:

```
# get most recent tags (might need to go to n-1, depending on when you create the tag)
git fetch --all --tags --prune
prev_tag=$(git tag -l  --merged HEAD --sort=creatordate | tail -n1)

# pre-fetch indexes for this branch
PREFETCH_INDEX_YAML="https://github.com/appsody/stacks/releases/download/$prev_tag/experimental-index.yaml \
https://github.com/appsody/stacks/releases/download/$prev_tag/incubator-index.yaml \
https://github.com/appsody/stacks/releases/download/$prev_tag/stable-index.yaml"

# download most recent published/released templates
./ci/prefetch.sh

# prevent creation of missing archives
export PACKAGE_WHEN_MISSING=false

# build only spring boot (scripts fixed to not require base_dir as parameter)
./ci/build.sh incubator/java-spring-boot2
```

Information about pre-fetched template archives that do not have a version in the name will be saved into files in ./ci/build. 

When ./ci/build.sh is run to selectively build the spring boot stack, pre-downloaded templates will be used. 

For un-versioned archive files, the side files in ci/build will be used to test that the stack they were built for matches the stack being written into the index, e.g. template was built for swift-v1.2.3, and swift/stack.yaml is also version 1.2.3.

For versioned archives, it is a simple file name match: the archive with the right name either exists or it doesn’t.

### Related Issues:
Partial fix for kabanero-io/kabanero-collection#60