### PR TITLE
java-spring-boot on liberty: bumped version

### DIFF
--- a/experimental/java-spring-boot2-liberty/image/project/pom.xml
+++ b/experimental/java-spring-boot2-liberty/image/project/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>dev.appsody</groupId>
     <artifactId>java-spring-boot2-liberty</artifactId>
-    <version>0.1.3</version>
+    <version>0.1.4</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/experimental/java-spring-boot2-liberty/stack.yaml
+++ b/experimental/java-spring-boot2-liberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Spring Boot® on Open Liberty
-version: 0.1.3
+version: 0.1.4
 description: Spring Boot on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java

--- a/experimental/java-spring-boot2-liberty/templates/default/pom.xml
+++ b/experimental/java-spring-boot2-liberty/templates/default/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>dev.appsody</groupId>
         <artifactId>java-spring-boot2-liberty</artifactId>
-        <version>0.1.3</version>
+        <version>0.1.4</version>
     </parent>
 
     <groupId>dev.appsody.starter.java-spring-boot2-liberty</groupId>


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

Bumped version of java-spring-boot2-liberty to fix pinned specific patch version in the templates