### PR TITLE
Add Maven Wrapper to Spring Boot2 on Open Liberty stack.

### DIFF
--- a/experimental/java-spring-boot2-liberty/image/Dockerfile-stack
+++ b/experimental/java-spring-boot2-liberty/image/Dockerfile-stack
@@ -12,6 +12,7 @@ COPY ./config /config
 WORKDIR /project/
 
 RUN mkdir -p /mvn/repository
+RUN mvn -Dmaven.repo.local=/mvn/repository -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
 RUN mvn -Dmaven.repo.local=/mvn/repository install dependency:go-offline -DskipTests
 
 WORKDIR /project/user-app

--- a/experimental/java-spring-boot2-liberty/image/project/.appsody-init.bat
+++ b/experimental/java-spring-boot2-liberty/image/project/.appsody-init.bat
@@ -1,1 +1,1 @@
-mvn install -Denforcer.skip=true
+mvnw install -Denforcer.skip=true

--- a/experimental/java-spring-boot2-liberty/image/project/.appsody-init.sh
+++ b/experimental/java-spring-boot2-liberty/image/project/.appsody-init.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-mvn install -Denforcer.skip=true
+./mvnw install -Denforcer.skip=true

--- a/experimental/java-spring-boot2-liberty/image/project/pom.xml
+++ b/experimental/java-spring-boot2-liberty/image/project/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>dev.appsody</groupId>
     <artifactId>java-spring-boot2-liberty</artifactId>
-    <version>0.1.4</version>
+    <version>0.1.5</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/experimental/java-spring-boot2-liberty/stack.yaml
+++ b/experimental/java-spring-boot2-liberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Spring Boot® on Open Liberty
-version: 0.1.4
+version: 0.1.5
 description: Spring Boot on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java

--- a/experimental/java-spring-boot2-liberty/templates/default/pom.xml
+++ b/experimental/java-spring-boot2-liberty/templates/default/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>dev.appsody</groupId>
         <artifactId>java-spring-boot2-liberty</artifactId>
-        <version>0.1.4</version>
+        <version>0.1.5</version>
     </parent>
 
     <groupId>dev.appsody.starter.java-spring-boot2-liberty</groupId>


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

Adds Maven Wrapper to Spring Boot2 on Open Liberty Stack

