### PR TITLE
skip building or publishing docker images

### DIFF
--- a/ci/env.sh
+++ b/ci/env.sh
@@ -26,6 +26,11 @@ if [ -z "$REPO_LIST" ]; then
     export REPO_LIST="experimental incubator stable"
 fi
 
+# build docker images, publish them
+if [ -z $DOCKER_BUILD ]; then
+    export DOCKER_BUILD=true
+fi
+
 # dockerhub org for publishing stack
 if [ -z $DOCKERHUB_ORG ]; then
     export DOCKERHUB_ORG=appsody

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -66,7 +66,7 @@ do
                     stack_version_minor=`echo $stack_version | cut -d. -f2`
                     stack_version_patch=`echo $stack_version | cut -d. -f3`
 
-                    if [ -d $stack_dir/image ]
+                    if [ -d $stack_dir/image ] && [ "$DOCKER_BUILD" == "true" ]
                     then
                         docker build -t $DOCKERHUB_ORG/$stack_id \
                             -t $DOCKERHUB_ORG/$stack_id:$stack_version_major \

--- a/ci/release.sh
+++ b/ci/release.sh
@@ -34,16 +34,18 @@ do
     fi
 done
 
-# dockerhub/docker registry login in
-echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin $DOCKER_REGISTRY
+if [ "$DOCKER_BUILD" == "true" ]; then
+    # dockerhub/docker registry login in
+    echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin $DOCKER_REGISTRY
 
-# iterate over each stack
-for repo_stack in $STACKS_LIST
-do
-    stack_id=`echo ${repo_stack/*\//}`
-    echo "Releasing stack images for: $stack_id"
-    docker push $DOCKERHUB_ORG/$stack_id
-done
+    # iterate over each stack
+    for repo_stack in $STACKS_LIST
+    do
+        stack_id=`echo ${repo_stack/*\//}`
+        echo "Releasing stack images for: $stack_id"
+        docker push $DOCKERHUB_ORG/$stack_id
+    done
+fi
 
 # expose an extension point for running after main 'release' processing
 if [ -f $base_dir/ci/ext/post_release.sh ]


### PR DESCRIPTION
An option to skip building Docker images or publishing them.

### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`
ci/release.sh
<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->