### PR TITLE
Add support for SSL to nginx image

### DIFF
--- a/ci/nginx/Dockerfile
+++ b/ci/nginx/Dockerfile
@@ -2,6 +2,7 @@ ARG NGINX_IMAGE=nginx:stable-alpine
 FROM $NGINX_IMAGE
 
 COPY nginx/nginx.conf  /etc/nginx/nginx.conf
+COPY nginx/nginx-ssl.conf  /etc/nginx/nginx-ssl.conf
 COPY nginx/startup.sh  /opt/startup.sh
 COPY assets            /opt/www/public
 COPY build/prefetch    /opt/www/public
@@ -10,5 +11,12 @@ COPY build/index-src   /opt/index-src
 RUN rm /opt/www/public/*-local.yaml
 
 EXPOSE 8080
+EXPOSE 8443
+
+RUN touch /var/run/nginx.pid && \
+  chown -R nginx:0 /var/run/nginx.pid /var/cache/nginx /opt/www/public /etc/nginx /run && \
+  chmod -R g=u /opt/www/public /var/cache/nginx /etc/nginx /var/run/nginx.pid /run
+
+USER nginx
 
 ENTRYPOINT ["/opt/startup.sh"]

--- a/ci/nginx/docker-compose.yml
+++ b/ci/nginx/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     container_name: "appsody-index"
     ports:
       - "8008:8080"
+      - "8003:8443"
     environment:
       - EXTERNAL_URL=http://localhost:8008/
 
@@ -17,5 +18,5 @@ services:
     entrypoint: ""
     command: sh -c "/opt/startup.sh; cat /opt/www/public/*.yaml; ls /opt/www/public"
     environment:
-      - EXTERNAL_URL=http://localhost:8008/
+      - EXTERNAL_URL=https://localhost:8003/
       - DRY_RUN=true

--- a/ci/nginx/nginx-ssl.conf
+++ b/ci/nginx/nginx-ssl.conf
@@ -1,0 +1,72 @@
+user nginx;
+worker_processes  1;
+daemon off;
+
+# Default nginx image symlinks:
+# ln -sf /dev/stdout /var/log/nginx/access.log
+# ln -sf /dev/stderr /var/log/nginx/error.log
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+  worker_connections  1024;
+}
+
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  sendfile       off;
+  tcp_nopush     on;
+  tcp_nodelay    on;
+
+  gzip  on;
+  gzip_min_length 50;
+  gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon;
+
+  keepalive_timeout 65;
+
+  ## 8080 -- Redirect almost everything to SSL
+  server {
+    listen    8080 default;
+
+    location /health {
+      access_log  off;
+      error_log   off;
+      default_type application/json;
+      return 200  'ok';
+    }
+
+    location / {
+      return    301 https://$host:8443$request_uri;
+    }
+  }
+
+
+  server {
+    ssl_certificate     /etc/tls/private/tls.crt;
+    ssl_certificate_key /etc/tls/private/tls.key;
+    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+
+    listen    8443 ssl;
+
+    access_log  /var/log/nginx/access.log;
+
+    error_page  404    /404.html;
+
+    server_name localhost;
+
+    location / {
+      root  /opt/www/public;
+      autoindex on;
+    }
+
+    location /health {
+      access_log  off;
+      error_log   off;
+      return 200  'ok';
+    }
+  }
+}

--- a/ci/nginx/startup.sh
+++ b/ci/nginx/startup.sh
@@ -1,11 +1,20 @@
 #!/bin/sh
 
-cp -R /opt/index-src/* /opt/www/public
+CONF_FILE=
+if echo $EXTERNAL_URL | grep https
+then
+    CONF_FILE="-f nginx-ssl.conf"
+fi
 
 # Replace the resource paths in index yaml files to match the specified external URL
 find /opt/www/public -name '*.yaml' -exec sed -i -e "s|{{EXTERNAL_URL}}|${EXTERNAL_URL%/}|" {} \;
 
 if [ -z "${DRY_RUN}" ]
 then
-    exec nginx
+    exec nginx $CONF_FILE
+else
+    echo "Dry run"
+    echo using $CONF_FILE
+    echo user id is $(id -u)
+    echo group id is $(id -g)
 fi


### PR DESCRIPTION
Requires PR #219 

### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

### Changes

If `EXTERNAL_URL` contains `https`, use the SSL configuration file instead. 
The docker-compose file maps ports to avoid conflict with application containers when testing locally:
 
*  8080 is mapped to 8008 
*  8443 is mapped to 8003

### Related Issues:

Requires PR #219 
Related to issue kabanero-io/kabanero-collection#60
Includes changes from PR kabanero-io/collections#35