### PR TITLE
Copy license files to stack containers

### DIFF
--- a/ci/package.sh
+++ b/ci/package.sh
@@ -68,6 +68,9 @@ do
 
                     if [ -d $stack_dir/image ]
                     then
+                        # Make license file available during image BUILDING
+                        cp $stack_dir/LICENSE $stack_dir/image/
+
                         docker build -t $DOCKERHUB_ORG/$stack_id \
                             -t $DOCKERHUB_ORG/$stack_id:$stack_version_major \
                             -t $DOCKERHUB_ORG/$stack_id:$stack_version_major.$stack_version_minor \

--- a/experimental/java-spring-boot2-liberty/image/Dockerfile-stack
+++ b/experimental/java-spring-boot2-liberty/image/Dockerfile-stack
@@ -7,6 +7,7 @@ RUN  apt-get -qq update \
   && apt-get -qq clean \
   && rm -rf /tmp/* /var/lib/apt/lists/*
 
+COPY ./LICENSE /licenses/
 COPY ./project /project
 COPY ./config /config
 WORKDIR /project/

--- a/experimental/nodejs-functions/image/Dockerfile-stack
+++ b/experimental/nodejs-functions/image/Dockerfile-stack
@@ -10,6 +10,7 @@ ENV APPSODY_INSTALL="npm install --prefix user-app/functions && npm audit fix --
 
 ENV APPSODY_TEST="npm test && npm test --prefix user-app/functions"
 
+COPY ./LICENSE /licenses/
 COPY ./project /project/user-app
 COPY ./config /config
 WORKDIR /project

--- a/experimental/python-flask/image/Dockerfile-stack
+++ b/experimental/python-flask/image/Dockerfile-stack
@@ -24,6 +24,7 @@ ENV APPSODY_TEST="python -m unittest discover -s test -p *.py"
 ENV APPSODY_TEST_ON_CHANGE=""
 ENV APPSODY_TEST_KILL=false
 
+COPY ./LICENSE /licenses/
 COPY ./project /project
 COPY ./config /config
 WORKDIR /project

--- a/experimental/quarkus/image/Dockerfile-stack
+++ b/experimental/quarkus/image/Dockerfile-stack
@@ -1,6 +1,7 @@
 # Dockerfile for building the stack
 FROM quay.io/quarkus/centos-quarkus-maven:19.0.2
 
+COPY ./LICENSE /licenses/
 COPY ./project /project
 COPY ./config /config
 WORKDIR /project
@@ -30,4 +31,3 @@ ENV PORT=8080
 
 EXPOSE 8080
 EXPOSE 5005
-

--- a/incubator/java-microprofile/image/Dockerfile-stack
+++ b/incubator/java-microprofile/image/Dockerfile-stack
@@ -7,6 +7,7 @@ RUN  apt-get -qq update \
   && apt-get -qq clean \
   && rm -rf /tmp/* /var/lib/apt/lists/*
 
+COPY ./LICENSE /licenses/
 COPY ./project /project
 COPY ./config /config
 WORKDIR /project/

--- a/incubator/java-spring-boot2/image/Dockerfile-stack
+++ b/incubator/java-spring-boot2/image/Dockerfile-stack
@@ -8,6 +8,7 @@ RUN  apt-get -qq update \
   && apt-get -qq clean \
   && rm -rf /tmp/* /var/lib/apt/lists/*
 
+COPY ./LICENSE /licenses/
 COPY ./project /project
 COPY ./config /config
 COPY ./mvn-stack-settings.xml /usr/share/maven/conf/settings.xml

--- a/incubator/nodejs-express/image/Dockerfile-stack
+++ b/incubator/nodejs-express/image/Dockerfile-stack
@@ -21,6 +21,7 @@ ENV APPSODY_TEST="npm test && npm test --prefix user-app"
 ENV APPSODY_TEST_ON_CHANGE=""
 ENV APPSODY_TEST_KILL=false
 
+COPY ./LICENSE /licenses/
 COPY ./project /project
 COPY ./config /config
 WORKDIR /project

--- a/incubator/nodejs-loopback/image/Dockerfile-stack
+++ b/incubator/nodejs-loopback/image/Dockerfile-stack
@@ -22,6 +22,7 @@ ENV APPSODY_TEST="npm test && npm test --prefix user-app"
 ENV APPSODY_TEST_ON_CHANGE=""
 ENV APPSODY_TEST_KILL=false
 
+COPY ./LICENSE /licenses/
 COPY ./project /project
 COPY ./config /config
 WORKDIR /project

--- a/incubator/nodejs/image/Dockerfile-stack
+++ b/incubator/nodejs/image/Dockerfile-stack
@@ -21,6 +21,7 @@ ENV APPSODY_TEST="npm test"
 ENV APPSODY_TEST_ON_CHANGE=""
 ENV APPSODY_TEST_KILL=false
 
+COPY ./LICENSE /licenses/
 COPY ./project /project
 COPY ./config /config
 

--- a/incubator/swift/image/Dockerfile-stack
+++ b/incubator/swift/image/Dockerfile-stack
@@ -26,6 +26,7 @@ ENV APPSODY_TEST="swift test"
 ENV APPSODY_TEST_ON_CHANGE=""
 ENV APPSODY_TEST_KILL=false
 
+COPY ./LICENSE /licenses/
 COPY ./project /project
 COPY ./config /config
 WORKDIR /project/user-app


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

This PR adds the stack license files to the stack docker images. As discussed with Neeraj the `package.sh` script has been updated to copy each stacks `LICENSE` file to the docker build root so it can be copied into the stacks image at build time.

Each stacks `Dockerfile-stack` has been updates to copy the `LICENSE` file into the `/licenses/` directory.