### PR TITLE
move prefetched binaries to the build directory

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -7,8 +7,8 @@ set -e
 if [ $# -gt 0 ]
 then
     # ignore the old basedir argument
-    dir=$(cd "$1" && pwd)
-    if [ -f $dir/RELEASE.md ]
+    dir=$1
+    if [ -d $dir ] && [ -f $dir/RELEASE.md ]
     then
         shift
     fi

--- a/ci/nginx/Dockerfile
+++ b/ci/nginx/Dockerfile
@@ -4,6 +4,7 @@ FROM $NGINX_IMAGE
 COPY nginx/nginx.conf  /etc/nginx/nginx.conf
 COPY nginx/startup.sh  /opt/startup.sh
 COPY assets            /opt/www/public
+COPY build/prefetch    /opt/www/public
 COPY build/index-src   /opt/index-src
 
 RUN rm /opt/www/public/*-local.yaml

--- a/ci/nginx/docker-compose.yml
+++ b/ci/nginx/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     image: "appsody/appsody-index"
     container_name: "appsody-verify"
     entrypoint: ""
-    command: sh -c "/opt/startup.sh; cat /opt/www/public/*.yaml"
+    command: sh -c "/opt/startup.sh; cat /opt/www/public/*.yaml; ls /opt/www/public"
     environment:
       - EXTERNAL_URL=http://localhost:8008/
       - DRY_RUN=true

--- a/ci/prefetch.sh
+++ b/ci/prefetch.sh
@@ -19,7 +19,9 @@ then
     verify="shasum --status -c -"
 fi
 
-cd $assets_dir
+mkdir -p $build_dir/prefetch
+cd $build_dir/prefetch
+
 if [ -n "${INDEX_LIST}" ]
 then
     for url in ${INDEX_LIST}
@@ -48,7 +50,7 @@ then
                     # ./ci/build/prefetch-stack_id-template_id 0.3.2
                     echo '#!/bin/bash
 
-cd "'${assets_dir}'"
+cd "'${build_dir}'/prefetch"
 # Fetched from '${url}' on '$(date)'
 # '${x}'
 checksum="'$($create $filename)'"


### PR DESCRIPTION
1. Move prefetch template archives into the build directory so they are not included in the GitHub release.
2. Clean up prefetch template archives when a new one is built
3. Include prefetched template archives (from new location) in the index image.

Signed-off-by: Erin Schnabel <schnabel@us.ibm.com>

### Checklist:

- [ ] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ ] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->