### PR TITLE
Allow buildah in place of docker CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /ci/assets
 /ci/package
 /ci/build
+/ci/release
 /ci/nginx/docker-compose.override.yml
 **/.DS_Store
 **/node_modules

--- a/ci/nginx/docker-compose.yml
+++ b/ci/nginx/docker-compose.yml
@@ -20,3 +20,9 @@ services:
     environment:
       - EXTERNAL_URL=https://localhost:8003/
       - DRY_RUN=true
+
+  registry:
+    image: "registry:2"
+    container_name: "registry"
+    ports:
+     - "5000:5000"

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -64,9 +64,9 @@ do
 
                     if [ -d $stack_dir/image ]
                     then
-                        docker build \
+                        image_build \
                             --build-arg GIT_ORG_REPO=$GIT_ORG_REPO \
-                            --build-arg DOCKERHUB_ORG=$DOCKERHUB_ORG \
+                            --build-arg IMAGE_REGISTRY_ORG=$IMAGE_REGISTRY_ORG \
                             --build-arg STACK_ID=$stack_id \
                             --build-arg MAJOR_VERSION=$stack_version_major \
                             --build-arg MINOR_VERSION=$stack_version_minor \
@@ -74,16 +74,16 @@ do
                             --label "org.opencontainers.image.created=$(date +%Y-%m-%dT%H:%M:%S%z)" \
                             --label "org.opencontainers.image.version=${stack_version}" \
                             --label "org.opencontainers.image.revision=$(git log -1 --pretty=%H)" \
-                            -t $DOCKERHUB_ORG/$stack_id \
-                            -t $DOCKERHUB_ORG/$stack_id:$stack_version_major \
-                            -t $DOCKERHUB_ORG/$stack_id:$stack_version_major.$stack_version_minor \
-                            -t $DOCKERHUB_ORG/$stack_id:$stack_version_major.$stack_version_minor.$stack_version_patch \
+                            -t $IMAGE_REGISTRY_ORG/$stack_id \
+                            -t $IMAGE_REGISTRY_ORG/$stack_id:$stack_version_major \
+                            -t $IMAGE_REGISTRY_ORG/$stack_id:$stack_version_major.$stack_version_minor \
+                            -t $IMAGE_REGISTRY_ORG/$stack_id:$stack_version_major.$stack_version_minor.$stack_version_patch \
                             -f $stack_dir/image/Dockerfile-stack $stack_dir/image
 
-                        echo "$DOCKERHUB_ORG/$stack_id" >> $build_dir/image_list
-                        echo "$DOCKERHUB_ORG/$stack_id:$stack_version_major" >> $build_dir/image_list
-                        echo "$DOCKERHUB_ORG/$stack_id:$stack_version_major.$stack_version_minor" >> $build_dir/image_list
-                        echo "$DOCKERHUB_ORG/$stack_id:$stack_version_major.$stack_version_minor.$stack_version_patch" >> $build_dir/image_list
+                        echo "$IMAGE_REGISTRY_ORG/$stack_id" >> $build_dir/image_list
+                        echo "$IMAGE_REGISTRY_ORG/$stack_id:$stack_version_major" >> $build_dir/image_list
+                        echo "$IMAGE_REGISTRY_ORG/$stack_id:$stack_version_major.$stack_version_minor" >> $build_dir/image_list
+                        echo "$IMAGE_REGISTRY_ORG/$stack_id:$stack_version_major.$stack_version_minor.$stack_version_patch" >> $build_dir/image_list
                     fi
                 else
                     echo -e "\n- SKIPPING stack image: $repo_name/$stack_id"
@@ -130,9 +130,9 @@ do
                             # build template archive; include version in the file name
                             if [ $stack_version_major -gt 0 ]
                             then
-                                echo "stack: "$DOCKERHUB_ORG/$stack_id:$stack_version_major > $template_dir/.appsody-config.yaml
+                                echo "stack: "$IMAGE_REGISTRY_ORG/$stack_id:$stack_version_major > $template_dir/.appsody-config.yaml
                             else
-                                echo "stack: "$DOCKERHUB_ORG/$stack_id:$stack_version_major.$stack_version_minor > $template_dir/.appsody-config.yaml
+                                echo "stack: "$IMAGE_REGISTRY_ORG/$stack_id:$stack_version_major.$stack_version_minor > $template_dir/.appsody-config.yaml
                             fi
 
                             tar -cz -f $assets_dir/$versioned_archive -C $template_dir .
@@ -221,7 +221,7 @@ fi
 exec_hooks $script_dir/ext/post_package.d
 
 # create appsody-index from contents of assets directory after post-processing
-echo -e "\nBUILDING: $DOCKERHUB_ORG/$INDEX_IMAGE:${INDEX_VERSION}"
+echo -e "\nBUILDING: $IMAGE_REGISTRY_ORG/$INDEX_IMAGE:${INDEX_VERSION}"
 
 nginx_arg=
 if [ -n "$NGINX_IMAGE" ]
@@ -229,10 +229,10 @@ then
     nginx_arg="--build-arg NGINX_IMAGE=$NGINX_IMAGE"
 fi
 
-docker build $nginx_arg \
- -t $DOCKERHUB_ORG/$INDEX_IMAGE \
- -t $DOCKERHUB_ORG/$INDEX_IMAGE:${INDEX_VERSION} \
+image_build $nginx_arg \
+ -t $IMAGE_REGISTRY_ORG/$INDEX_IMAGE \
+ -t $IMAGE_REGISTRY_ORG/$INDEX_IMAGE:${INDEX_VERSION} \
  -f $script_dir/nginx/Dockerfile $script_dir
 
-echo "$DOCKERHUB_ORG/$INDEX_IMAGE" >> $build_dir/image_list
-echo "$DOCKERHUB_ORG/$INDEX_IMAGE:${INDEX_VERSION}" >> $build_dir/image_list
+echo "$IMAGE_REGISTRY_ORG/$INDEX_IMAGE" >> $build_dir/image_list
+echo "$IMAGE_REGISTRY_ORG/$INDEX_IMAGE:${INDEX_VERSION}" >> $build_dir/image_list

--- a/ci/release.sh
+++ b/ci/release.sh
@@ -21,8 +21,7 @@ do
     fi
 done
 
-# dockerhub/docker registry login in
-echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin $DOCKER_REGISTRY
+image_registry_login
 
 if [ -f $build_dir/image_list ]
 then
@@ -30,21 +29,9 @@ then
     do
         if [ "$line" != "" ]
         then
-            echo "Pushing image $line"
-            docker push $line
+            image_push $line
         fi
     done < $build_dir/image_list
-else
-    # iterate over each stack
-    for repo_stack in $STACKS_LIST
-    do
-        stack_id=`echo ${repo_stack/*\//}`
-        echo "Releasing stack images for: $stack_id"
-        docker push $DOCKERHUB_ORG/$stack_id
-    done
-
-    echo "Releasing stack index"
-    docker push $DOCKERHUB_ORG/appsody_index
 fi
 
 # expose an extension point for running after main 'release' processing


### PR DESCRIPTION
Replace DOCKER* environment variables with IMAGE_REGISTRY*
Define functions for docker operations, to allow buildah replacement
Allow registry push to be disabled

Signed-off-by: Erin Schnabel <schnabel@us.ibm.com>

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ ] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->