### PR TITLE
java-spring-boot2: init script path; hush progress

### DIFF
--- a/incubator/java-spring-boot2/image/Dockerfile-stack
+++ b/incubator/java-spring-boot2/image/Dockerfile-stack
@@ -15,11 +15,12 @@ COPY ./mvn-stack-settings.xml /usr/share/maven/conf/settings.xml
 COPY ./mvn-stack-settings.xml /project/mvn-stack-settings.xml
 
 WORKDIR /project
-RUN mvn -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
+RUN mvn --no-transfer-progress -B -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
 
 WORKDIR /project/user-app
 
 ENV APPSODY_USER_RUN_AS_LOCAL=true
+ENV APPSODY_PROJECT_DIR="/project"
 
 ENV APPSODY_MOUNTS=".:/project/user-app;~/.m2/repository:/mvn/repository"
 ENV APPSODY_DEPS=

--- a/incubator/java-spring-boot2/image/project/.appsody-init.bat
+++ b/incubator/java-spring-boot2/image/project/.appsody-init.bat
@@ -1,4 +1,4 @@
 if not exist %SystemDrive%%HOMEPATH%\.m2\repository\ (
   mkdir %SystemDrive%%HOMEPATH%\.m2\repository
 )
-mvnw install -q -f /project/appsody-boot2-pom.xml
+mvnw install -q -f ./appsody-boot2-pom.xml

--- a/incubator/java-spring-boot2/image/project/.appsody-init.sh
+++ b/incubator/java-spring-boot2/image/project/.appsody-init.sh
@@ -18,4 +18,4 @@ if [ ! -d ~/.m2/repository ]; then
   mkdir -p ~/.m2/repository
 fi
 
-./mvnw install -q -f /project/appsody-boot2-pom.xml
+./mvnw install -q -f ./appsody-boot2-pom.xml

--- a/incubator/java-spring-boot2/image/project/appsody-boot2-pom.xml
+++ b/incubator/java-spring-boot2/image/project/appsody-boot2-pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>dev.appsody</groupId>
   <artifactId>spring-boot2-stack</artifactId>
-  <version>0.3.7</version>
+  <version>0.3.8</version>
   <packaging>pom</packaging>
 
   <name>Appsody Spring Boot2 stack</name>

--- a/incubator/java-spring-boot2/image/project/java-spring-boot2-build.sh
+++ b/incubator/java-spring-boot2/image/project/java-spring-boot2-build.sh
@@ -32,7 +32,7 @@ error() {
 
 run_mvn () {
   echo -e "${GREEN}> mvn $@${NO_COLOR}"
-  mvn "$@"
+  mvn --no-transfer-progress "$@"
 }
 
 version() {

--- a/incubator/java-spring-boot2/stack.yaml
+++ b/incubator/java-spring-boot2/stack.yaml
@@ -1,5 +1,5 @@
 name: Spring Boot®
-version: 0.3.7
+version: 0.3.8
 description: Spring Boot using OpenJ9 and Maven
 license: Apache-2.0
 language: java

--- a/incubator/java-spring-boot2/templates/default/pom.xml
+++ b/incubator/java-spring-boot2/templates/default/pom.xml
@@ -6,7 +6,7 @@
   <parent><!--required parent POM-->
     <groupId>dev.appsody</groupId>
     <artifactId>spring-boot2-stack</artifactId>
-    <version>0.3.7</version>
+    <version>0.3.8</version>
     <relativePath/>
   </parent>
 

--- a/incubator/java-spring-boot2/templates/kotlin/pom.xml
+++ b/incubator/java-spring-boot2/templates/kotlin/pom.xml
@@ -6,7 +6,7 @@
   <parent><!--required parent POM-->
     <groupId>dev.appsody</groupId>
     <artifactId>spring-boot2-stack</artifactId>
-    <version>0.3.7</version>
+    <version>0.3.8</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
Make maven quieter for docker/build logs
Fix path in init scripts

Signed-off-by: Erin Schnabel <schnabel@us.ibm.com>

### Checklist:

- [ ] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ ] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->