### PR TITLE
Create a basic test for use in the release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /ci/build
 /ci/release
 /ci/nginx/docker-compose.override.yml
+**/00_local
 **/.DS_Store
 **/node_modules
 **/*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
   - docker
 
 script:
-  - . ./ci/build.sh
+  - travis_wait ./ci/build.sh
 
 # note before_deploy will run before each deploy provider
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ services:
   - docker
 
 script:
-  - travis_wait ./ci/build.sh
+  - travis_wait 30 bash ./ci/build.sh
 
 # note before_deploy will run before each deploy provider
 before_deploy:
-  - . ./ci/release.sh
+  - ./ci/release.sh
 
 deploy:
   provider: releases

--- a/ci/ext/pre_list.d/10_travis
+++ b/ci/ext/pre_list.d/10_travis
@@ -71,6 +71,6 @@ then
     if [ -z "${STACKS_LIST}" ]
     then
         echo "Choosing a subset of stacks to test with CI/CD changes"
-        export STACKS_LIST="incubator/java-microprofile incubator/java-spring-boot2 incubator/nodejs experimental/java-spring-boot2"
+        export STACKS_LIST="incubator/java-microprofile incubator/java-spring-boot2 incubator/nodejs experimental/java-spring-boot2-liberty"
     fi
 fi

--- a/ci/ext/pre_list.d/10_travis
+++ b/ci/ext/pre_list.d/10_travis
@@ -67,4 +67,10 @@ then
             exit 1
         fi
     fi
+
+    if [ -z "${STACKS_LIST}" ]
+    then
+        echo "Choosing a subset of stacks to test with CI/CD changes"
+        export STACKS_LIST="incubator/java-microprofile incubator/java-spring-boot2 incubator/nodejs experimental/java-spring-boot2"
+    fi
 fi

--- a/ci/ext/pre_test.d/10_travis
+++ b/ci/ext/pre_test.d/10_travis
@@ -1,0 +1,40 @@
+#!/bin/bash
+# invoked from ci/test.env
+
+if [ -z "${APPSODY_CLI_RELEASE_URL}" ]
+then
+    APPSODY_CLI_RELEASE_URL=https://api.github.com/repos/appsody/appsody/releases/latest
+fi
+if [ -z "${APPSODY_CLI_DOWNLOAD_URL}" ]
+then
+    APPSODY_CLI_DOWNLOAD_URL=https://github.com/appsody/appsody/releases/download/
+fi
+if [ -z "${APPSODY_CLI_FALLBACK}" ]
+then
+    APPSODY_CLI_FALLBACK=0.4.2
+fi
+
+if [ "$TRAVIS" == "true" ]
+then
+    cli_dir=$build_dir/cli
+    mkdir -p $cli_dir
+
+    curl -L -s -o $cli_dir/release.json "$APPSODY_CLI_RELEASE_URL"
+    release_tag=$(cat $cli_dir/release.json | grep "tag_name" | cut -d'"' -f4)
+    if ! [[ "$release_tag" =~ [0-9]+\.[0-9]+\.[0-9]+ ]]
+    then
+        echo "Falling back to ${APPSODY_CLI_FALLBACK}"
+        cat $cli_dir/release.json
+        release_tag=${APPSODY_CLI_FALLBACK}
+    fi
+
+    cli_deb="appsody_${release_tag}_amd64.deb"
+    cli_dist=https://github.com/appsody/appsody/releases/download/${release_tag}/${cli_deb}
+
+    echo " release_tag=${release_tag}"
+    echo " cli_deb=${cli_deb}"
+    echo " cli_dist=${cli_dist}"
+
+    curl -L -s -o "$cli_dir/$cli_deb" "$cli_dist"
+    sudo dpkg -i $cli_dir/$cli_deb
+fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -6,8 +6,136 @@
 # expose an extension point for running before main 'test' processing
 exec_hooks $script_dir/ext/pre_test.d
 
-echo -e "\nNo tests implemented yet"
+pull_policy=$APPSODY_PULL_POLICY
+
+if ! which appsody
+then
+    echo "appsody CLI not found on the path"
+    return 1
+fi
+
+wait_until_ready() {
+    i=0
+    while true
+    do
+        if eval $1
+        then
+            break
+        else
+            ((i=i+1))
+            if [ $i -gt 60 ]
+            then
+                printf '\n'
+                return 1
+            fi
+            printf '.'
+            sleep 2s
+        fi
+    done
+    printf '\n'
+    return 0
+}
+
+test_template() {
+    local template=$2
+    local stack=$(basename $1)
+    local index=$(dirname $1)-index
+    local index_local=$(dirname $1)-index-local
+    local error=0
+
+    echo ""
+    echo "=== Testing $stack : $template"
+    echo ""
+
+    if appsody list $index_local | grep -q $stack
+    then
+        local repo=$index_local
+        export APPSODY_PULL_POLICY=$pull_policy
+    else
+        local repo=$index
+        export APPSODY_PULL_POLICY=ALWAYS
+    fi
+
+    rm -rf $build_dir/test/$repo/$stack/$template
+    mkdir -pv $build_dir/test/$repo/$stack/$template
+    pushd $build_dir/test/$repo/$stack/$template
+
+    echo ""
+    echo "> appsody init -v $repo/$stack $template"
+    echo ""
+    if 2>init.log 1>&2 appsody init -v --overwrite $repo/$stack $template
+    then
+        echo ""
+        echo "> appsody run -P --name $stack-$template"
+        echo ""
+        2>run.log 1>&2 appsody run -P --name $stack-$template &
+
+        echo "Waiting for container to start"
+        if ! wait_until_ready "appsody ps | grep -q $stack-$template"
+        then
+            cat run.log
+            ((error=error+1))
+        fi
+        echo error=$error
+        appsody ps
+
+        echo ""
+        echo "> appsody stop --name $stack-$template"
+        echo ""
+        appsody stop --name $stack-$template
+        if ! wait_until_ready "appsody ps | grep -q $stack-$template; [ \$? -eq 1 ]"
+        then
+            ((error=error+1))
+        fi
+        echo error=$error
+        appsody ps
+
+        echo ""
+        echo "> appsody build"
+        echo ""
+        if ! appsody build
+        then
+            ((error=error+1))
+        fi
+        echo error=$error
+
+        echo "Finished with ${error} error(s)"
+    else
+        echo "Unable to initialize project"
+        cat init.log
+        exit 1
+    fi
+    popd
+}
+
+for x in $assets_dir/*.yaml
+do
+    if [ -f $x ] && grep template $x > /dev/null
+    then
+        index_url=file://$x
+        y=$(basename $x)
+        if appsody repo list | grep -q -e "^\*\?${y%.*}"
+        then
+            echo "Repo ${y%.*} exists"
+        else
+            echo "Installing repo ${y%.*} : $index_url"
+            appsody repo add ${y%.*} $index_url
+        fi
+    fi
+done
+
+appsody repo list
+export APPSODY_PULL_POLICY=IFNOTPRESENT
+
+for stack in $STACKS_LIST
+do
+    for template in "$stack/templates/*"
+    do
+        test_template "$stack" "$(basename $template)"
+    done
+done
+
+export APPSODY_PULL_POLICY=$pull_policy
 
 # expose an extension point for running after main 'test' processing
 exec_hooks $script_dir/ext/post_test.d
-


### PR DESCRIPTION
This adds basic operational tests to `ci/test.sh`. For each specified stack, it will run `appsody test` and `appsody build` to make sure tests can run, and the final OCI image can be built correctly.

Verify behavior: 

```
STACKS_LIST=incubator/java-spring-boot2 ./ci/test.sh
```

### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- N/A Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).

