### PR TITLE
Restart on trigger

### DIFF
--- a/incubator/java-spring-boot2/image/Dockerfile-stack
+++ b/incubator/java-spring-boot2/image/Dockerfile-stack
@@ -31,7 +31,7 @@ ENV APPSODY_DEPS=
 
 ENV APPSODY_WATCH_DIR="/project/user-app/src"
 ENV APPSODY_WATCH_IGNORE_DIR=""
-ENV APPSODY_WATCH_REGEX=""
+ENV APPSODY_WATCH_REGEX=".*"
 
 ENV APPSODY_RUN="/project/java-spring-boot2-build.sh run"
 ENV APPSODY_RUN_ON_CHANGE="/project/java-spring-boot2-build.sh recompile"

--- a/incubator/java-spring-boot2/image/project/appsody-boot2-pom.xml
+++ b/incubator/java-spring-boot2/image/project/appsody-boot2-pom.xml
@@ -171,6 +171,30 @@
             <optional>true</optional>
           </dependency>
         </dependencies>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-antrun-plugin</artifactId>
+              <version>1.1</version>
+              <executions>
+                <execution>
+                  <id>trigger-spring-restart</id>
+                  <phase>compile</phase>
+                  <goals>
+                    <goal>run</goal>
+                  </goals>
+                  <configuration>
+                    <tasks>
+                      <echo>Triggering Spring app restart.</echo>
+                      <touch file="${basedir}/.appsody-spring-trigger" />
+                    </tasks>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>      
+          </plugins>          
+        </build>
     </profile>
   </profiles>
 

--- a/incubator/java-spring-boot2/image/project/appsody-boot2-pom.xml
+++ b/incubator/java-spring-boot2/image/project/appsody-boot2-pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>dev.appsody</groupId>
   <artifactId>spring-boot2-stack</artifactId>
-  <version>0.3.9</version>
+  <version>0.3.10</version>
   <packaging>pom</packaging>
 
   <name>Appsody Spring Boot2 stack</name>

--- a/incubator/java-spring-boot2/stack.yaml
+++ b/incubator/java-spring-boot2/stack.yaml
@@ -1,5 +1,5 @@
 name: Spring Boot®
-version: 0.3.9
+version: 0.3.10
 description: Spring Boot using OpenJ9 and Maven
 license: Apache-2.0
 language: java

--- a/incubator/java-spring-boot2/templates/default/src/main/resources/application.properties
+++ b/incubator/java-spring-boot2/templates/default/src/main/resources/application.properties
@@ -1,2 +1,4 @@
 #enable the actuator endpoints for health, metrics, and prometheus.
 management.endpoints.web.exposure.include=health,metrics,prometheus,liveness
+spring.devtools.restart.additional-paths=.
+spring.devtools.restart.trigger-file=.appsody-spring-trigger

--- a/incubator/java-spring-boot2/templates/kotlin/src/main/resources/application.properties
+++ b/incubator/java-spring-boot2/templates/kotlin/src/main/resources/application.properties
@@ -1,2 +1,4 @@
 #enable the actuator endpoints for health, metrics, and prometheus.
 management.endpoints.web.exposure.include=health,metrics,prometheus,liveness
+spring.devtools.restart.additional-paths=.
+spring.devtools.restart.trigger-file=.appsody-spring-trigger


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

Spring dev tools used to manage restart when .class or related resources were updated. 

There appears to be a timing window, during a maven build, when Spring may choose to restart the app, and bring the app up based on partially compiled changes, and then also not notice that further compiles occured during the app start, leaving the app running in an inconsistent state.

Moving the restart to be trigger based will avoid this window, Spring dev tools is configured here to restart only when a trigger file is updated, and the parent pom build is updated to touch that file after the compile step has completed. 

Non-compiling-editors: (vim/notepad/ultraedit etc)
Edits are made to the source, detected by the appsody watcher, which in turn triggers the mvn compile, that after completion touches the trigger file, causing application restart.

Compiling-editors (vscode/IDEs)
Edits are made to the source, and locally recompiled, and mapped to the target folder, the edits in turn trigger the mvn recompile server side that is able to avoid compiling files that do not need recompiling, and after completion, touches the trigger file, causing application restart.

Consequences/Differences:
Restart behavior with this change is more controlled, being now solely managed by the mvn build within the container. That said, IDEs _could_ opt to touch the trigger file themselves if they felt they stood to gain from such customisation, but doing so without somehow also disabling the appsody watcher would only cause duplicate restart events.

The Spring restart watcher was more app aware than the mvn trigger approach, only performing restarts when resources altered that required them (eg, no restart needed for html edits). The mvn build is less intelligent and will always touch the trigger after the recompile. Overall this will likely mean many more restarts than before, thankfully Spring apps restart fairly quickly. 

As part of these changes, the appsody watcher is also upgraded to a `.*` regex. Currently it's defaulting to `""` which actually implies `*.java`. At a minimum Spring would need `.yaml|.yml|.java|.properties|.xml` and any other extensions the user chose (eg, `.sql` for Spring data preload table data). So it's cleaner to leave that as `.*`. We'd actually benefit here more from saying which files NOT to restart on, but `APPSODY_WATCH_REGEX` doesn't support negative matching. 

### Related Issues:
Will resolve #294 through the `.*` change. 
Will resolve #252 through the trigger change.