### PR TITLE
suppress maven progress output for vertx

### DIFF
--- a/experimental/vertx/image/Dockerfile-stack
+++ b/experimental/vertx/image/Dockerfile-stack
@@ -13,23 +13,23 @@ COPY ./LICENSE /licenses/
 COPY ./project /project
 COPY ./config /config
 WORKDIR /project/
-RUN mvn install dependency:go-offline -DskipTests
+RUN mvn -B install dependency:go-offline -DskipTests
 
 ENV APPSODY_USER_RUN_AS_LOCAL=true
 
 ENV APPSODY_MOUNTS=".:/project/user-app/;~/.m2/repository:/.m2/repository"
 ENV APPSODY_DEPS=
 
-ENV APPSODY_RUN="mvn compile vertx:run"
+ENV APPSODY_RUN="mvn -B compile vertx:run"
 ENV APPSODY_RUN_ON_CHANGE=""
 ENV APPSODY_RUN_KILL=false
 
-ENV APPSODY_DEBUG="mvn compile vertx:debug"
+ENV APPSODY_DEBUG="mvn -B compile vertx:debug"
 ENV APPSODY_DEBUG_ON_CHANGE=""
 ENV APPSODY_DEBUG_KILL=false
 
-ENV APPSODY_TEST="mvn test"
-ENV APPSODY_TEST_ON_CHANGE="mvn test"
+ENV APPSODY_TEST="mvn -B test"
+ENV APPSODY_TEST_ON_CHANGE="mvn -B test"
 ENV APPSODY_TEST_KILL=true
 
 WORKDIR /project/user-app

--- a/experimental/vertx/image/project/Dockerfile
+++ b/experimental/vertx/image/project/Dockerfile
@@ -9,7 +9,7 @@ COPY . /project
 WORKDIR /project/user-app
 COPY ./user-app/src ./src
 COPY ./user-app/pom.xml ./
-RUN mvn clean package
+RUN mvn -B clean package
 
 FROM adoptopenjdk:8-jre-openj9
 

--- a/experimental/vertx/image/project/pom.xml
+++ b/experimental/vertx/image/project/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>dev.appsody</groupId>
     <artifactId>vertx</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <packaging>pom</packaging>
 
   <properties>

--- a/experimental/vertx/stack.yaml
+++ b/experimental/vertx/stack.yaml
@@ -1,5 +1,5 @@
 name: Eclipse Vert.x
-version: 0.1.0
+version: 0.1.1
 description: Eclipse Vert.x runtime for running Java applications
 license: Eclipse Public License - Version 2.0
 language: java

--- a/experimental/vertx/templates/default/pom.xml
+++ b/experimental/vertx/templates/default/pom.xml
@@ -5,7 +5,7 @@
   <parent>
       <groupId>dev.appsody</groupId>
       <artifactId>vertx</artifactId>
-      <version>0.1.0</version>
+      <version>0.1.1</version>
   </parent>
 
   <groupId>org.acme.quickstart</groupId>


### PR DESCRIPTION
Signed-off-by: Erin Schnabel <schnabel@us.ibm.com>

### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [X] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [X] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

` --no-transfer-progress` to suppress transfer progress (bloats log files)

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->