### PR TITLE
suppress maven progress output for Spring+Liberty

### DIFF
--- a/experimental/java-spring-boot2-liberty/image/Dockerfile-stack
+++ b/experimental/java-spring-boot2-liberty/image/Dockerfile-stack
@@ -13,8 +13,8 @@ COPY ./config /config
 WORKDIR /project/
 
 RUN mkdir -p /mvn/repository
-RUN mvn -Dmaven.repo.local=/mvn/repository -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
-RUN mvn -Dmaven.repo.local=/mvn/repository install dependency:go-offline -DskipTests
+RUN mvn -B -Dmaven.repo.local=/mvn/repository -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
+RUN mvn -B -Dmaven.repo.local=/mvn/repository install dependency:go-offline -DskipTests
 
 WORKDIR /project/user-app
 
@@ -25,17 +25,17 @@ ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/target
 ENV APPSODY_WATCH_REGEX="^.*(.xml|.java|.properties)$"
 
-ENV APPSODY_INSTALL="../validate.sh && mvn -Dmaven.repo.local=/mvn/repository install -DskipTests"
+ENV APPSODY_INSTALL="../validate.sh && mvn -B -Dmaven.repo.local=/mvn/repository install -DskipTests"
 
-ENV APPSODY_RUN="mvn -Dmaven.repo.local=/mvn/repository liberty:run"
+ENV APPSODY_RUN="mvn -B -Dmaven.repo.local=/mvn/repository liberty:run"
 ENV APPSODY_RUN_ON_CHANGE="mvn -Dmaven.repo.local=/mvn/repository package -DskipTests"
 ENV APPSODY_RUN_KILL=false
 
-ENV APPSODY_DEBUG="mvn -Dmaven.repo.local=/mvn/repository liberty:debug"
+ENV APPSODY_DEBUG="mvn -B -Dmaven.repo.local=/mvn/repository liberty:debug"
 ENV APPSODY_DEBUG_ON_CHANGE="mvn -Dmaven.repo.local=/mvn/repository package -DskipTests"
 ENV APPSODY_DEBUG_KILL=false
 
-ENV APPSODY_TEST="mvn -Dmaven.repo.local=/mvn/repository verify"
+ENV APPSODY_TEST="mvn -B -Dmaven.repo.local=/mvn/repository verify"
 ENV APPSODY_TEST_ON_CHANGE=""
 ENV APPSODY_TEST_KILL=false
 

--- a/experimental/java-spring-boot2-liberty/image/project/Dockerfile
+++ b/experimental/java-spring-boot2-liberty/image/project/Dockerfile
@@ -7,7 +7,7 @@ COPY . /project
 
 WORKDIR /project/user-app
 
-RUN mvn install -DskipTests
+RUN mvn -B install -DskipTests
 
 RUN cd target && \
     unzip *.zip && \

--- a/experimental/java-spring-boot2-liberty/image/project/pom.xml
+++ b/experimental/java-spring-boot2-liberty/image/project/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>dev.appsody</groupId>
     <artifactId>java-spring-boot2-liberty</artifactId>
-    <version>0.1.6</version>
+    <version>0.1.7</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/experimental/java-spring-boot2-liberty/stack.yaml
+++ b/experimental/java-spring-boot2-liberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Spring Boot® on Open Liberty
-version: 0.1.6
+version: 0.1.7
 description: Spring Boot on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java

--- a/experimental/java-spring-boot2-liberty/templates/default/pom.xml
+++ b/experimental/java-spring-boot2-liberty/templates/default/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>dev.appsody</groupId>
         <artifactId>java-spring-boot2-liberty</artifactId>
-        <version>0.1.6</version>
+        <version>0.1.7</version>
     </parent>
 
     <groupId>dev.appsody.starter.java-spring-boot2-liberty</groupId>


### PR DESCRIPTION
Signed-off-by: Erin Schnabel <schnabel@us.ibm.com>

### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [X] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [X] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

`--no-transfer-progress` to suppress transfer progress (bloats log files)

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->