### PR TITLE
suppress maven progress output for microprofile

### DIFF
--- a/incubator/java-microprofile/image/Dockerfile-stack
+++ b/incubator/java-microprofile/image/Dockerfile-stack
@@ -13,8 +13,8 @@ COPY ./config /config
 
 WORKDIR /project/
 RUN mkdir -p /mvn/repository
-RUN mvn -Dmaven.repo.local=/mvn/repository -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
-RUN mvn -Dmaven.repo.local=/mvn/repository install dependency:go-offline -DskipTests
+RUN mvn --no-transfer-progress -Dmaven.repo.local=/mvn/repository -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
+RUN mvn --no-transfer-progress -Dmaven.repo.local=/mvn/repository install dependency:go-offline -DskipTests
 
 WORKDIR /project/user-app
 
@@ -25,17 +25,17 @@ ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/target
 ENV APPSODY_WATCH_REGEX="^.*(.xml|.java|.properties)$"
 
-ENV APPSODY_INSTALL="../validate.sh && mvn -Dmaven.repo.local=/mvn/repository install -DskipTests"
+ENV APPSODY_INSTALL="../validate.sh && mvn --no-transfer-progress -Dmaven.repo.local=/mvn/repository install -DskipTests"
 
-ENV APPSODY_RUN="mvn -Dmaven.repo.local=/mvn/repository liberty:run"
-ENV APPSODY_RUN_ON_CHANGE="mvn -Dmaven.repo.local=/mvn/repository package -DskipTests"
+ENV APPSODY_RUN="mvn --no-transfer-progress -Dmaven.repo.local=/mvn/repository liberty:run"
+ENV APPSODY_RUN_ON_CHANGE="mvn --no-transfer-progress -Dmaven.repo.local=/mvn/repository package -DskipTests"
 ENV APPSODY_RUN_KILL=false
 
-ENV APPSODY_DEBUG="mvn -Dmaven.repo.local=/mvn/repository liberty:debug"
-ENV APPSODY_DEBUG_ON_CHANGE="mvn -Dmaven.repo.local=/mvn/repository package -DskipTests"
+ENV APPSODY_DEBUG="mvn --no-transfer-progress -Dmaven.repo.local=/mvn/repository liberty:debug"
+ENV APPSODY_DEBUG_ON_CHANGE="mvn --no-transfer-progress -Dmaven.repo.local=/mvn/repository package -DskipTests"
 ENV APPSODY_DEBUG_KILL=false
 
-ENV APPSODY_TEST="mvn -Dmaven.repo.local=/mvn/repository verify"
+ENV APPSODY_TEST="mvn --no-transfer-progress -Dmaven.repo.local=/mvn/repository verify"
 ENV APPSODY_TEST_ON_CHANGE=""
 ENV APPSODY_TEST_KILL=false
 

--- a/incubator/java-microprofile/image/project/pom.xml
+++ b/incubator/java-microprofile/image/project/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>dev.appsody</groupId>
     <artifactId>java-microprofile</artifactId>
-    <version>0.2.11</version>
+    <version>0.2.12</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/incubator/java-microprofile/stack.yaml
+++ b/incubator/java-microprofile/stack.yaml
@@ -1,5 +1,5 @@
 name: Eclipse MicroProfile®
-version: 0.2.11
+version: 0.2.12
 description: Eclipse MicroProfile on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java

--- a/incubator/java-microprofile/templates/default/pom.xml
+++ b/incubator/java-microprofile/templates/default/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>dev.appsody</groupId>
         <artifactId>java-microprofile</artifactId>
-        <version>0.2.11</version>
+        <version>0.2.12</version>
     </parent>
 
     <groupId>dev.appsody.starter.java-microprofile</groupId>


### PR DESCRIPTION
Signed-off-by: Erin Schnabel <schnabel@us.ibm.com>

### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [X] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [X] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

`--no-transfer-progress` to suppress transfer progress (bloats log files)

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->