### PR TITLE
[java-spring-boot2] Use git and version data in stack image

### DIFF
--- a/ci/env.sh
+++ b/ci/env.sh
@@ -93,7 +93,7 @@ stderr() {
 }
 
 trace() {
-    if [ -z "${VERBOSE}" ]
+    if [ "${VERBOSE}" == "true" ]
     then
         for x in "$@"
         do

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -81,7 +81,7 @@ do
                             -f $stack_dir/image/Dockerfile-stack $stack_dir/image \
                             > ${build_dir}/image.$stack_id.$stack_version.log 2>&1
                         then
-                            trace  "Output from image build" ${build_dir}/image.$stack_id.$stack_version.log
+                            trace  "Output from image build" "${build_dir}/image.$stack_id.$stack_version.log"
 
                             echo "created $IMAGE_REGISTRY_ORG/$stack_id:$stack_version"
                             echo "$IMAGE_REGISTRY_ORG/$stack_id" >> $build_dir/image_list
@@ -248,13 +248,13 @@ if ${CI_WAIT_FOR} image_build $nginx_arg \
     -f $script_dir/nginx/Dockerfile $script_dir \
     > ${build_dir}/image.$INDEX_IMAGE.${INDEX_VERSION}.log
 then
-    trace  "Output from appsody index build" ${build_dir}/image.$INDEX_IMAGE.${INDEX_VERSION}.log
+    trace  "Output from appsody index build" "${build_dir}/image.$INDEX_IMAGE.${INDEX_VERSION}.log"
 
     echo "created $IMAGE_REGISTRY_ORG/$INDEX_IMAGE:${INDEX_VERSION}"
     echo "$IMAGE_REGISTRY_ORG/$INDEX_IMAGE" >> $build_dir/image_list
     echo "$IMAGE_REGISTRY_ORG/$INDEX_IMAGE:${INDEX_VERSION}" >> $build_dir/image_list
 else
     echo "failed building $IMAGE_REGISTRY_ORG/$INDEX_IMAGE:${INDEX_VERSION}"
-    cat ${build_dir}/image.$INDEX_IMAGE.${INDEX_VERSION}.log
+    cat "${build_dir}/image.$INDEX_IMAGE.${INDEX_VERSION}.log"
     exit 1
 fi

--- a/incubator/java-spring-boot2/image/Dockerfile-stack
+++ b/incubator/java-spring-boot2/image/Dockerfile-stack
@@ -1,5 +1,12 @@
 FROM maven:3.6-ibmjava-8
-LABEL maintainer="IBM Java Engineering at IBM Cloud"
+
+# passed in via package script
+ARG GIT_ORG_REPO=appsody/stacks
+ARG IMAGE_REGISTRY_ORG=appsody
+ARG STACK_ID=java-spring-boot2
+ARG MAJOR_VERSION=0
+ARG MINOR_VERSION=1
+ARG PATCH_VERSION=0
 
 # Ensure up to date / patched OS
 RUN  apt-get -qq update \
@@ -15,11 +22,24 @@ COPY ./config /config
 COPY ./mvn-stack-settings.xml /usr/share/maven/conf/settings.xml
 COPY ./mvn-stack-settings.xml /project/mvn-stack-settings.xml
 
-# OSGI core for version range processing
-RUN  /project/util/check_version build
+# Build utility for version range processing
+# Install maven wrapper in /project
+RUN mkdir -p /mvn/repository \
+ && /project/util/check_version build \
+ && cd /project \
+ && mvn --no-transfer-progress -B -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
 
-WORKDIR /project
-RUN mvn --no-transfer-progress -B -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
+# Update maven artifacts to use stack version information
+# Update Dockerfile to build from this appsody stack image (by range)
+RUN if [ ${MAJOR_VERSION} -eq 0 ]; then \
+      export IMAGE_VERSION=${MAJOR_VERSION}.${MINOR_VERSION}; \
+    else \
+      export IMAGE_VERSION=${MAJOR_VERSION}; \
+    fi \
+ && export MAVEN_ARTIFACT_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}" \
+ && sed -i -e "s|{{APPSODY_STACK}}|${IMAGE_REGISTRY_ORG}/${STACK_ID}:${IMAGE_VERSION}|" \
+           -e "s|{{APPSODY_STACK_FULL}}|${IMAGE_REGISTRY_ORG}/${STACK_ID}:${MAVEN_ARTIFACT_VERSION}|" /project/Dockerfile \
+ && sed -i -e "s|{{MAVEN_ARTIFACT_VERSION}}|${MAVEN_ARTIFACT_VERSION}|" /project/appsody-boot2-pom.xml
 
 WORKDIR /project/user-app
 
@@ -48,6 +68,7 @@ ENV APPSODY_TEST_KILL=true
 ENV PORT=8080
 
 EXPOSE 8080
+EXPOSE 8443
 EXPOSE 5005
 EXPOSE 35729
 ENTRYPOINT ["/project/java-spring-boot2-build.sh", "run"]

--- a/incubator/java-spring-boot2/image/project/.dockerignore
+++ b/incubator/java-spring-boot2/image/project/.dockerignore
@@ -2,3 +2,4 @@
 **/.git
 **/.gitignore
 **/.vscode
+**/.appsody-spring-trigger

--- a/incubator/java-spring-boot2/image/project/Dockerfile
+++ b/incubator/java-spring-boot2/image/project/Dockerfile
@@ -1,36 +1,34 @@
-FROM maven:3.6-ibmjava-8 as compile
-LABEL maintainer="IBM Java Engineering at IBM Cloud"
+FROM {{APPSODY_STACK}} as compile
+
+#setup project folder for java build step
+COPY . /project
+
+WORKDIR /project/user-app
+
+RUN /project/util/check_version build \
+ && /project/java-spring-boot2-build.sh package
+
+####
+FROM adoptopenjdk:8-jdk-openj9
 
 # Ensure up to date / patched OS
 RUN  apt-get -qq update \
   && apt-get -qq install -y curl wget xmlstarlet unzip \
   && DEBIAN_FRONTEND=noninteractive apt-get -qq upgrade -y \
   && apt-get -qq clean \
-  && rm -rf /tmp/* /var/lib/apt/lists/* \
-  && mkdir -p /mvn/repository
-
-#setup project folder for java build step
-COPY . /project
-COPY ./mvn-stack-settings.xml /usr/share/maven/conf/settings.xml
-
-# OSGI core for version range processing
-RUN  /project/util/check_version build
-
-WORKDIR /project/user-app
-
-RUN /project/java-spring-boot2-build.sh package
-
-####
-FROM adoptopenjdk:8-jdk-openj9
+  && rm -rf /tmp/* /var/lib/apt/lists/*
 
 ARG artifactId=appsody-spring
 ARG version=1.0-SNAPSHOT
 ENV JVM_ARGS=""
 
-LABEL maintainer="IBM Java Engineering at IBM Cloud"
-LABEL org.opencontainers.image.version=${version}
-LABEL org.opencontainers.image.title=${artifactId}
+LABEL org.opencontainers.image.version="${version}"
+LABEL org.opencontainers.image.title="${artifactId}"
+LABEL appsody.stack="{{APPSODY_STACK_FULL}}"
 
 COPY --from=compile /project/user-app/target/app.jar /app.jar
 
-ENTRYPOINT [ "sh", "-c", "java $JVM_ARGS -Djava.security.egd=file:/dev/./urandom -jar /app.jar" ]
+EXPOSE 8080
+EXPOSE 8443
+
+ENTRYPOINT [ "sh", "-c", "exec java $JVM_ARGS -Djava.security.egd=file:/dev/./urandom -jar /app.jar" ]

--- a/incubator/java-spring-boot2/image/project/appsody-boot2-pom.xml
+++ b/incubator/java-spring-boot2/image/project/appsody-boot2-pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>dev.appsody</groupId>
   <artifactId>spring-boot2-stack</artifactId>
-  <version>0.3.13</version>
+  <version>{{MAVEN_ARTIFACT_VERSION}}</version>
   <packaging>pom</packaging>
 
   <name>Appsody Spring Boot2 stack</name>
@@ -50,7 +50,6 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
- 
   </properties>
 
   <dependencyManagement>

--- a/incubator/java-spring-boot2/image/project/java-spring-boot2-build.sh
+++ b/incubator/java-spring-boot2/image/project/java-spring-boot2-build.sh
@@ -6,18 +6,20 @@ else
 fi
 
 if [[ "$color_prompt" == "yes" ]]; then
-      BLUE="\033[0;34m"
-    GREEN="\033[0;32m"
-    WHITE="\033[1;37m"
-      RED="\033[0;31m"
-    YELLOW="\033[0;33m"
-  NO_COLOR="\033[0m"
+       BLUE="\033[0;34m"
+      GREEN="\033[0;32m"
+      WHITE="\033[1;37m"
+        RED="\033[0;31m"
+     YELLOW="\033[0;33m"
+   NO_COLOR="\033[0m"
+  MVN_COLOR=""
 else
         BLUE=""
       GREEN=""
       WHITE=""
         RED=""
-  NO_COLOUR=""
+   NO_COLOR=""
+  MVN_COLOR="-Dstyle.color=never"
 fi
 
 note() {
@@ -32,7 +34,7 @@ error() {
 
 run_mvn () {
   echo -e "${GREEN}> mvn $@${NO_COLOR}"
-  mvn --no-transfer-progress "$@"
+  mvn --no-transfer-progress ${MVN_COLOR} "$@"
 }
 
 common() {
@@ -122,12 +124,15 @@ package() {
 
 debug() {
   note "Build and debug project in the foreground"
-  run_mvn spring-boot:run -Dspring-boot.run.jvmArguments='-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005'
+  run_mvn -Dmaven.test.skip=true \
+    -Dspring-boot.run.jvmArguments='-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005' \
+    spring-boot:run
 }
 
 run() {
-  note "Build and run project in the foreground"  
-  run_mvn clean -Dmaven.test.skip=true spring-boot:run
+  note "Build and run project in the foreground"
+  run_mvn -Dmaven.test.skip=true \
+    clean spring-boot:run
 }
 
 test() {
@@ -153,12 +158,12 @@ case "${ACTION}" in
   ;;
   debug)
     common
-    export APPSODY_DEV_MODE=debug    
+    export APPSODY_DEV_MODE=debug
     debug
   ;;
   run)
     common
-    export APPSODY_DEV_MODE=run    
+    export APPSODY_DEV_MODE=run
     run
   ;;
   test)

--- a/incubator/java-spring-boot2/templates/default/.gitignore
+++ b/incubator/java-spring-boot2/templates/default/.gitignore
@@ -1,4 +1,5 @@
 /target/*
+.appsody-spring-trigger
 
 ### STS ###
 .apt_generated

--- a/incubator/java-spring-boot2/templates/default/pom.xml
+++ b/incubator/java-spring-boot2/templates/default/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <groupId>dev.appsody</groupId>
-  <artifactId>application</artifactId>
+  <artifactId>default-application</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 

--- a/incubator/java-spring-boot2/templates/kotlin/.gitignore
+++ b/incubator/java-spring-boot2/templates/kotlin/.gitignore
@@ -1,4 +1,5 @@
 /target/*
+.appsody-spring-trigger
 
 ### STS ###
 .apt_generated

--- a/incubator/java-spring-boot2/templates/kotlin/pom.xml
+++ b/incubator/java-spring-boot2/templates/kotlin/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <groupId>dev.appsody</groupId>
-  <artifactId>application</artifactId>
+  <artifactId>kotlin-application</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 

--- a/incubator/java-spring-boot2/templates/kotlin/src/main/resources/application.properties
+++ b/incubator/java-spring-boot2/templates/kotlin/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 #enable the actuator endpoints for health, metrics, and prometheus.
 management.endpoints.web.exposure.include=health,metrics,prometheus,liveness
-spring.devtools.restart.additional-paths=.
+spring.devtools.restart.additional-paths=./target
 spring.devtools.restart.trigger-file=.appsody-spring-trigger


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

Arguments passed in by package.sh are used to version the stack image
The compile stage of the Dockerfile used to build the final image is based on the stack image

Fix bugs in Spring Boot stack:
- Exposed ports
- exec used so signals go to java process


### Related Issues:

Related to #181 and #324 

---
After these changes are applied, the stack image contains (already defined by package.sh):  
```            "Labels": {
                "appsody.stack": "appsody/java-spring-boot2:0.3.13",
                "org.opencontainers.image.created": "2019-09-23T13:23:11-0400",
                "org.opencontainers.image.revision": "9eb6942fc3ee2afe2f208970dd2ab3e5de20f70c",
                "org.opencontainers.image.version": "0.3.13"
            }
```

The final docker image contains the stack version as well: 
```
            "Labels": {
                "appsody.stack": "appsody/java-spring-boot2:0.3.13",
                "org.opencontainers.image.title": "appsody-spring",
                "org.opencontainers.image.version": "1.0-SNAPSHOT"
            }
```

To do more, I need to move the templates into the stack (a follow-on PR).