### PR TITLE
nodejs-express: added environment variable to production image

### DIFF
--- a/incubator/nodejs-express/image/config/app-deploy.yaml
+++ b/incubator/nodejs-express/image/config/app-deploy.yaml
@@ -19,6 +19,7 @@ spec:
       port: APPSODY_PORT
     initialDelaySeconds: 5
     periodSeconds: 2
+    timeoutSeconds: 1
   livenessProbe:
     failureThreshold: 12
     httpGet:

--- a/incubator/nodejs-express/image/project/Dockerfile
+++ b/incubator/nodejs-express/image/project/Dockerfile
@@ -36,6 +36,8 @@ COPY --chown=node:node --from=0 /project/user-app/node_modules /project/user-app
 
 WORKDIR /project
 
+ENV NODE_PATH=/project/user-app/node_modules
+
 ENV NODE_ENV production
 ENV PORT 3000
 

--- a/incubator/nodejs-express/image/project/package.json
+++ b/incubator/nodejs-express/image/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-express",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Node.js Express Stack",
   "license": "Apache-2.0",
   "repository": {

--- a/incubator/nodejs-express/stack.yaml
+++ b/incubator/nodejs-express/stack.yaml
@@ -1,5 +1,5 @@
 name: Node.js Express
-version: 0.2.5
+version: 0.2.6
 description: Express web framework for Node.js
 license: Apache-2.0
 language: nodejs


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->
Updated the production image to set the NODE_PATH environment variable to point to the node_modules folder in the user's app. Added timeoutSeconds for Readiness probe in `app-deploy.yaml`

### Related Issues:
Fixes #321 
Related to #313 