### PR TITLE
Fix issue with mismatching repo names

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -119,7 +119,7 @@ do
     then
         index_url=file://$x
         y=$(basename $x)
-        if appsody repo list | grep -q -e "^\*\?${y%.*}"
+        if appsody repo list | awk '{print $1}' | grep -e "${y%.*}$"
         then
             echo "Repo ${y%.*} exists"
         else


### PR DESCRIPTION
Signed-off-by: Steve Groeger <GROEGES@uk.ibm.com>

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

<!--- Describe your changes in detail -->
The test.sh file check for the existence of a specific repo name and if it doesn't exist it add it using the relevant index.yaml file.  The current code incorrectly detects that the  remote index (ie incubator-index) has already been added if the local index (ie incubator-index-local) has already been added. This small change is to correctly detect the existence of these indexes. 

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->