### PR TITLE
Use a variable as a prefix for the codewind index stack display names

### DIFF
--- a/ci/create_codewind_index.py
+++ b/ci/create_codewind_index.py
@@ -9,6 +9,10 @@ from collections import OrderedDict
 
 base_dir = os.path.abspath(os.path.dirname(sys.argv[0]))
 
+displayNamePrefix = "Appsody"
+if len(sys.argv) > 1:
+    displayNamePrefix = sys.argv[1]
+
 # directory to store assets for test or release
 assets_dir = base_dir + "/assets/"
 
@@ -31,7 +35,7 @@ for file in os.listdir(assets_dir):
 
                             # populate stack details
                             res = (OrderedDict([
-                                ("displayName", "Appsody " + item['name'] + template + " template"),
+                                ("displayName", displayNamePrefix + " " + item['name'] + template + " template"),
                                 ("description", item['description']),
                                 ("language", item['language']),
                                 ("projectType", "appsodyExtension"),

--- a/ci/env.sh
+++ b/ci/env.sh
@@ -59,6 +59,9 @@ mkdir -p $prefetch_dir
 # Build the Codewind index when the value is 'true' (requires PyYaml)
 # export CODEWIND_INDEX
 
+# Prefix to be used on the display name of the stack in the Codewind index file
+# export DISPLAY_NAME_PREFIX="Appsody"
+
 # Specify a wrapper where required for long-running commands
 CI_WAIT_FOR=
 
@@ -169,6 +172,11 @@ then
     else
         export IMAGE_REGISTRY_PUBLISH=true
     fi
+fi
+
+if [ -z "$DISPLAY_NAME_PREFIX" ]
+then
+    export DISPLAY_NAME_PREFIX="Appsody"
 fi
 
 image_build() {

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -215,7 +215,7 @@ do
 done
 
 if [ "$CODEWIND_INDEX" == "true" ]; then
-  python3 $script_dir/create_codewind_index.py
+  python3 $script_dir/create_codewind_index.py $DISPLAY_NAME_PREFIX
 fi
 
 # expose an extension point for running after main 'package' processing


### PR DESCRIPTION
Signed-off-by: Steve Groeger <GROEGES@uk.ibm.com>

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

<!--- Describe your changes in detail -->
The create_codewind_index python script is hard coded to specify "Appsody" at the start of the displayName of all the stacks that are included in the index.json file. There is a requirement to allow this to be configurable. This PR allows an environment variable to be set DISPLAY_NAME_PREFIX (eg export DISPLAY_NAME_PREFIX="Appsody") whose value will be used at the front of all the displayName strings in the index.json.
 
### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->