### PR TITLE
spring-boot: Fix path to pom.xml

### DIFF
--- a/incubator/java-spring-boot2/image/project/.appsody-init.sh
+++ b/incubator/java-spring-boot2/image/project/.appsody-init.sh
@@ -20,6 +20,5 @@ fi
 
 which java 2>&1 >/dev/null ; JAVA_KNOWN=$?
 if [ ! -z "$JAVA_HOME" ] || [ $JAVA_KNOWN = "0" ]; then
-  ./mvnw install -q -f project/appsody-boot2-pom.xml
+  ./mvnw install -q -f ./appsody-boot2-pom.xml
 fi
-

--- a/incubator/java-spring-boot2/image/project/appsody-boot2-pom.xml
+++ b/incubator/java-spring-boot2/image/project/appsody-boot2-pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>dev.appsody</groupId>
   <artifactId>spring-boot2-stack</artifactId>
-  <version>0.3.11</version>
+  <version>0.3.12</version>
   <packaging>pom</packaging>
 
   <name>Appsody Spring Boot2 stack</name>
@@ -192,8 +192,8 @@
                   </configuration>
                 </execution>
               </executions>
-            </plugin>      
-          </plugins>          
+            </plugin>
+          </plugins>
         </build>
     </profile>
   </profiles>

--- a/incubator/java-spring-boot2/stack.yaml
+++ b/incubator/java-spring-boot2/stack.yaml
@@ -1,5 +1,5 @@
 name: Spring Boot®
-version: 0.3.11
+version: 0.3.12
 description: Spring Boot using OpenJ9 and Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
Fixes path to parent pom in init.sh
Signed-off-by Neeraj Laad <neeraj.laad@gmail.com

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`
