### PR TITLE
alter trigger behavior

### DIFF
--- a/incubator/java-spring-boot2/image/Dockerfile-stack
+++ b/incubator/java-spring-boot2/image/Dockerfile-stack
@@ -31,7 +31,7 @@ ENV APPSODY_DEPS=
 
 ENV APPSODY_WATCH_DIR="/project/user-app/src"
 ENV APPSODY_WATCH_IGNORE_DIR=""
-ENV APPSODY_WATCH_REGEX=".*"
+ENV APPSODY_WATCH_REGEX="(^.*\.java$)|(^.*\.properties$)|(^.*\.yaml$)|(^.*\.html$)|(^.*\.sql$)|(^.*\.js$)|(^.*\.properties$)"
 
 ENV APPSODY_RUN="/project/java-spring-boot2-build.sh run"
 ENV APPSODY_RUN_ON_CHANGE="/project/java-spring-boot2-build.sh recompile"

--- a/incubator/java-spring-boot2/image/project/appsody-boot2-pom.xml
+++ b/incubator/java-spring-boot2/image/project/appsody-boot2-pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>dev.appsody</groupId>
   <artifactId>spring-boot2-stack</artifactId>
-  <version>0.3.12</version>
+  <version>0.3.13</version>
   <packaging>pom</packaging>
 
   <name>Appsody Spring Boot2 stack</name>
@@ -50,6 +50,7 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+ 
   </properties>
 
   <dependencyManagement>
@@ -161,7 +162,7 @@
         <id>dev</id>
         <activation>
           <property>
-            <name>env.APPSODY_RUN</name>
+            <name>env.APPSODY_DEV_MODE</name>
           </property>
         </activation>
         <dependencies>
@@ -187,7 +188,7 @@
                   <configuration>
                     <tasks>
                       <echo>Triggering Spring app restart.</echo>
-                      <touch file="${basedir}/.appsody-spring-trigger" />
+                      <touch file="${basedir}/target/.appsody-spring-trigger" />
                     </tasks>
                   </configuration>
                 </execution>

--- a/incubator/java-spring-boot2/image/project/java-spring-boot2-build.sh
+++ b/incubator/java-spring-boot2/image/project/java-spring-boot2-build.sh
@@ -126,7 +126,7 @@ debug() {
 }
 
 run() {
-  note "Build and run project in the foreground"
+  note "Build and run project in the foreground"  
   run_mvn clean -Dmaven.test.skip=true spring-boot:run
 }
 
@@ -144,6 +144,7 @@ fi
 
 case "${ACTION}" in
   recompile)
+    export APPSODY_DEV_MODE=run
     recompile
   ;;
   package)
@@ -152,14 +153,17 @@ case "${ACTION}" in
   ;;
   debug)
     common
+    export APPSODY_DEV_MODE=debug    
     debug
   ;;
   run)
     common
+    export APPSODY_DEV_MODE=run    
     run
   ;;
   test)
     common
+    export APPSODY_DEV_MODE=test
     test
   ;;
   *)

--- a/incubator/java-spring-boot2/stack.yaml
+++ b/incubator/java-spring-boot2/stack.yaml
@@ -1,5 +1,5 @@
 name: Spring Boot®
-version: 0.3.12
+version: 0.3.13
 description: Spring Boot using OpenJ9 and Maven
 license: Apache-2.0
 language: java

--- a/incubator/java-spring-boot2/templates/default/src/main/resources/application.properties
+++ b/incubator/java-spring-boot2/templates/default/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 #enable the actuator endpoints for health, metrics, and prometheus.
 management.endpoints.web.exposure.include=health,metrics,prometheus,liveness
-spring.devtools.restart.additional-paths=.
+spring.devtools.restart.additional-paths=./target
 spring.devtools.restart.trigger-file=.appsody-spring-trigger


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

Trigger behavior altered.. 
- watcher trigger restricted to a selection of filetypes (to be redone after resolution of APPSODY_WATCH_REGEX issue)
- spring trigger moved to target folder
- spring dev tools made optional based on launch script set env var rather than appsody run
