### PR TITLE
Adding a resource to MP template

### DIFF
--- a/incubator/java-microprofile/templates/default/src/main/java/dev/appsody/starter/StarterResource.java
+++ b/incubator/java-microprofile/templates/default/src/main/java/dev/appsody/starter/StarterResource.java
@@ -1,0 +1,18 @@
+package dev.appsody.starter;
+
+import static javax.ws.rs.core.MediaType.TEXT_HTML;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+@Path("/")
+public class StarterResource {
+
+    @GET
+    @Produces(TEXT_HTML)
+    public String info() {
+        return "Microservice v1";
+    }
+
+}


### PR DESCRIPTION
The current Java MicroProfile stack starter has an incomplete JAX-RS skeleton.  The URLs that are available are only the Liberty-provided endpoints, such as `/openapi/ui`, `/health` and `/metrics`.

The actual application, by default at `localhost:9080/starter` gives the following error:

```
Error 500: javax.servlet.ServletException: At least one provider or resource class should be specified for application class "dev.appsody.starter.StarterApplication
```

The issue is that no resources are actually provided.  This PR fixes this issue by providing a simple one, which can be easily customized.  With this PR the application endpoint `localhost:9080/starter` now outputs:  `Microservice v1`