### PR TITLE
[python-flask] Move flask to 1.1.1, plus other minor cleanups

### DIFF
--- a/incubator/python-flask/README.md
+++ b/incubator/python-flask/README.md
@@ -2,10 +2,7 @@
 
 The Python Flask stack provides a consistent way of developing web applications using [Flask](http://flask.pocoo.org). "Flask is a lightweight WSGI web application framework. It is designed to make getting started quick and easy, with the ability to scale up to complex applications."
 
-This stack is based on Python 3.7 and Flask 0.11.1 and enables health checking and application metrics out of the box. The stack also provides a set of unit tests. The stack also uses [flasgger](https://github.com/rochacbruno-archive/flasgger) to auto-generate swagger ui
-documentation and specification.
-
-Remote debugging of applications is enabled during `debug` mode using `ptvsd`, which enables you to connect using the debugger in VS Code. A VS Code debug launch configuration is also provided.
+This stack is based on Python 3.7 and Flask 1.1.1 and enables health checking and application metrics out of the box. The stack also provides a set of unit tests. The stack also uses [flasgger](https://github.com/rochacbruno-archive/flasgger) to auto-generate swagger ui documentation and specification.
 
 Note that the use of the Python Flask stack requires that `pipenv` is installed, which is used for both version management of Python versions (ensuring you are using the same version locally as used in the stack), and to allow you to specify your own dependencies in a Pipfile.
 
@@ -31,13 +28,11 @@ This stack also comes with Prometheus metrics, which has been preconfigured to w
 
 ## Templates
 
-Templates are used to create your local project and start your development. When initializing your project you will be provided with the simplest Node.js Express application you can write.
-
-This template only has a simple `__init__.py` file which implements the `/hello` endpoint and returns "Hello from Appsody!".
+Templates are used to create your local project and start your development. When initializing your project you will be provided with simple python flask application, implemented as a single `__init__.py` file which provides a `/hello` endpoint, which returns "Hello from Appsody!". You can then modify this to build out the endpoints required for your application.
 
 ## Getting Started
 
-1. Create a new folder in your local directory and initialize it using the Appsody CLI, e.g.:
+1. Create a new directory in your local directory and initialize it using the Appsody CLI, e.g.:
 
     ```bash
     mkdir my-project
@@ -64,6 +59,19 @@ This template only has a simple `__init__.py` file which implements the `/hello`
     - Health endpoint: http://localhost:8080/health
     - Metrics endpoint: http://localhost:8080/metrics
     - Swagger API doc: http://localhost:8080/apidocs
+
+## Debugging
+
+You can run also your application in debug mode using the following command:
+
+```bash
+    appsody debug
+```
+
+In debug mode, two aspects are enabled:
+
+1. The flask server is started in development mode, which enables the flask debugger
+1. The python debugger for Visual Studio (`ptvsd`) is enabled in the server, enabling remote debugging. The template included in this stack already has a `launch.json` for Visual Studio Code to enable remote debugging attach. This will be placed a directory called `.vscode` in the application directory that you initialize for Appsody. Opening your application in Visual Studio Code should cause this to be loaded.
 
 ## License
 

--- a/incubator/python-flask/image/Dockerfile-stack
+++ b/incubator/python-flask/image/Dockerfile-stack
@@ -1,6 +1,7 @@
 FROM python:3.7
 
-RUN pip install --user pipenv
+RUN pip install --upgrade pip \
+  && pip install --upgrade --user pipenv
 ENV PATH=/root/.local/bin:$PATH
 
 ENV APPSODY_MOUNTS=/:/project/userapp
@@ -12,15 +13,15 @@ ENV APPSODY_WATCH_REGEX="^.*.py$"
 ENV APPSODY_INSTALL="cd /project/userapp;pipenv lock -r > requirements.txt;python -m pip install -r requirements.txt -t /project/deps"
 
 ENV APPSODY_RUN="python -m flask run --host=0.0.0.0 --port=8080"
-ENV APPSODY_RUN_ON_CHANGE="python -m flask run --host=0.0.0.0 --port=8080"
+ENV APPSODY_RUN_ON_CHANGE=$APPSODY_RUN
 ENV APPSODY_RUN_KILL=true
 
-ENV APPSODY_DEBUG="python -m ptvsd --host 0.0.0.0 --port 5678 -m flask run --host=0.0.0.0 --port=8080"
-ENV APPSODY_DEBUG_ON_CHANGE="python -m ptvsd --host 0.0.0.0 --port 5678 -m flask run --host=0.0.0.0 --port=8080"
+ENV APPSODY_DEBUG="( export FLASK_ENV=development ; python -m ptvsd --host 0.0.0.0 --port 5678 -m flask run --host=0.0.0.0 --port=8080 )"
+ENV APPSODY_DEBUG_ON_CHANGE=$APPSODY_DEBUG
 ENV APPSODY_DEBUG_KILL=true
 
 ENV APPSODY_TEST="python -m unittest discover -s test -p *.py"
-ENV APPSODY_TEST_ON_CHANGE=""
+ENV APPSODY_TEST_ON_CHANGE=$APPSODY_TEST
 ENV APPSODY_TEST_KILL=false
 
 COPY ./LICENSE /licenses/

--- a/incubator/python-flask/image/Dockerfile-stack
+++ b/incubator/python-flask/image/Dockerfile-stack
@@ -16,7 +16,7 @@ ENV APPSODY_RUN="python -m flask run --host=0.0.0.0 --port=8080"
 ENV APPSODY_RUN_ON_CHANGE=$APPSODY_RUN
 ENV APPSODY_RUN_KILL=true
 
-ENV APPSODY_DEBUG="( export FLASK_ENV=development ; python -m ptvsd --host 0.0.0.0 --port 5678 -m flask run --host=0.0.0.0 --port=8080 )"
+ENV APPSODY_DEBUG="FLASK_ENV=development python -m ptvsd --host 0.0.0.0 --port 5678 -m flask run --host=0.0.0.0 --port=8080 --no-reload"
 ENV APPSODY_DEBUG_ON_CHANGE=$APPSODY_DEBUG
 ENV APPSODY_DEBUG_KILL=true
 
@@ -34,13 +34,13 @@ RUN python -m pip install -r requirements.txt -t /project/deps
 RUN python -m pip install ptvsd -t /project/deps
 
 # The next line gets round a problem with flasgger in that it has an unnecessary requirement on
-# jsonscheme of < 3.0.0, while other compoenents here need > 3.0.0. This is fixed in flasgger
+# jsonschema of < 3.0.0, while other components here need > 3.0.0. This is fixed in flasgger
 # PR 317, but a new release has not yet been pushed to pypi. The line below and the constraints
 # file can be removed once a new release is made (and flassger added to the regular Pipfile).
 # This constraints workaround will still cause an error on docker build, but this can be ignored.
 RUN python -m pip install -c constraints.txt flasgger==0.9.3
 
-ENV PORT=8080
+# ENV PORT=8080
 ENV PYTHONPATH=/project/deps
 ENV FLASK_APP=/project/server/__init__.py
 

--- a/incubator/python-flask/image/project/Dockerfile
+++ b/incubator/python-flask/image/project/Dockerfile
@@ -1,9 +1,10 @@
 FROM python:3.7
 
-RUN pip install --user pipenv
+RUN pip install --upgrade pip \
+  && pip install --upgrade --user pipenv
 ENV PATH=/root/.local/bin:$PATH
 
-WORKDIR /app
+WORKDIR /project
 
 COPY . ./
 # First we get the dependencies for the stack itself
@@ -11,15 +12,11 @@ RUN pipenv lock -r > requirements.txt
 # Now add in any for the app, that the developer has added (there seems to be
 # no easy way of specifying a different location for the Pipfile, so have to 
 # change the working directory!)
-WORKDIR /app/userapp
+WORKDIR /project/userapp
 RUN pipenv lock -r > ../requirements.txt
 # Now process the combined requirements
-WORKDIR /app
+WORKDIR /project
 RUN python -m pip install -r requirements.txt -t /project/deps
-COPY requirements.txt /tmp/requirements.txt
-RUN  pip install --upgrade pip \
-  && pip install --upgrade pipenv\
-  && pip install --upgrade -r /tmp/requirements.txt
 
 ENV PYTHONPATH=/project/deps
 ENV FLASK_APP=server/__init__.py

--- a/incubator/python-flask/image/project/Pipfile
+++ b/incubator/python-flask/image/project/Pipfile
@@ -6,8 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-gunicorn = "==19.7.1"
-Flask = "==0.11.1"
+Flask = "==1.1.1"
 flasgger = "==0.9.3"
 prometheus_client = "*"
 

--- a/incubator/python-flask/stack.yaml
+++ b/incubator/python-flask/stack.yaml
@@ -1,5 +1,5 @@
 name: Python Flask
-version: 0.1.3
+version: 0.1.4
 description: Flask web Framework for Python
 language: python
 maintainers:


### PR DESCRIPTION
The current flask version was rather old, this updates it 1.1.1.

There are also a few cleanups that have been done, e.g.:

- Ensure flask is in debug mode (as well as the already enabled ptvsd) in APPSODY_DEBUG
- Use $APPSODY_XXX wherever possible in Dockefile-stack
- Better document debug mode in README.
- Remove unused gunicorn
- Use standard /project directory in Dockerfile

Fixes #376