### PR TITLE
vertx: define timeout seconds for readiness probe

### DIFF
--- a/experimental/vertx/image/config/app-deploy.yaml
+++ b/experimental/vertx/image/config/app-deploy.yaml
@@ -17,6 +17,7 @@ spec:
       port: APPSODY_PORT
     initialDelaySeconds: 5
     periodSeconds: 2
+    timeoutSeconds: 1
   livenessProbe:
     failureThreshold: 12
     httpGet:

--- a/experimental/vertx/image/project/pom.xml
+++ b/experimental/vertx/image/project/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>dev.appsody</groupId>
     <artifactId>vertx</artifactId>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
     <packaging>pom</packaging>
 
   <properties>

--- a/experimental/vertx/stack.yaml
+++ b/experimental/vertx/stack.yaml
@@ -1,5 +1,5 @@
 name: Eclipse Vert.x
-version: 0.1.2
+version: 0.1.3
 description: Eclipse Vert.x runtime for running Java applications
 license: Eclipse Public License - Version 2.0
 language: java


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
Related to: https://github.com/appsody/stacks/issues/313#event-2683805266