### PR TITLE
spring-boot-liberty: add monitoring support and timeoutSeconds in app-deploy

### DIFF
--- a/experimental/java-spring-boot2-liberty/image/config/app-deploy.yaml
+++ b/experimental/java-spring-boot2-liberty/image/config/app-deploy.yaml
@@ -13,6 +13,20 @@ spec:
     annotations:
       prometheus.io/scrape: 'true'
       prometheus.io/path: '/actuator/prometheus'
+  monitoring:
+    endpoints:
+    - basicAuth:
+        password:
+          key: password
+          name: metrics-liberty
+        username:
+          key: username
+          name: metrics-liberty
+      interval: 5s
+      tlsConfig:
+        insecureSkipVerify: true
+    labels:
+      k8s-app: ""
   readinessProbe:
     failureThreshold: 12
     httpGet:
@@ -20,6 +34,7 @@ spec:
       port: APPSODY_PORT
     initialDelaySeconds: 5
     periodSeconds: 2
+    timeoutSeconds: 1
   livenessProbe:
     failureThreshold: 12
     httpGet:

--- a/experimental/java-spring-boot2-liberty/image/project/pom.xml
+++ b/experimental/java-spring-boot2-liberty/image/project/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>dev.appsody</groupId>
     <artifactId>java-spring-boot2-liberty</artifactId>
-    <version>0.1.9</version>
+    <version>0.1.10</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/experimental/java-spring-boot2-liberty/stack.yaml
+++ b/experimental/java-spring-boot2-liberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Spring Boot® on Open Liberty
-version: 0.1.9
+version: 0.1.10
 description: Spring Boot on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

Implements creating a ServiceMonitor CR for deployed applications (for stacks that use Prometheus). Also adds timeoutSeconds under the readiness probe to avoid Knative error.

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
Related to: https://github.com/appsody/stacks/issues/313#event-2683805266 and https://github.com/appsody/stacks/issues/391