### PR TITLE
rust: improve method for getting name of binary for build

### DIFF
--- a/experimental/rust/image/project/Dockerfile
+++ b/experimental/rust/image/project/Dockerfile
@@ -12,11 +12,9 @@ RUN cargo fetch
 COPY /user-app/src ./src
 
 # build for release
-RUN cargo build --release
-
-RUN echo "#!/bin/bash" > run.sh \
- && cargo run --release 2>&1 | tee output.txt \
- && bin=$(grep "Running " output.txt | sed -e 's/Running `\(.*\)`/\1/') \
+RUN cargo build --release \
+ && echo "#!/bin/bash" > run.sh \
+ && bin=$(find . -maxdepth 3 -perm -111 -type f | grep release/) \
  && echo ./${bin##*/} >> run.sh \
  && chmod 755 run.sh
 

--- a/experimental/rust/image/project/Dockerfile
+++ b/experimental/rust/image/project/Dockerfile
@@ -14,7 +14,7 @@ COPY /user-app/src ./src
 # build for release
 RUN cargo build --release \
  && echo "#!/bin/bash" > run.sh \
- && bin=$(find . -maxdepth 3 -perm -111 -type f | grep release/) \
+ && bin=$(find ./target/release -maxdepth 1 -perm -111 -type f| head -n 1) \
  && echo ./${bin##*/} >> run.sh \
  && chmod 755 run.sh
 

--- a/experimental/rust/stack.yaml
+++ b/experimental/rust/stack.yaml
@@ -1,4 +1,4 @@
-name: rust
+name: Rust
 version: 0.1.0 
 description: Runtime for Rust applications
 license: Apache-2.0

--- a/experimental/rust/stack.yaml
+++ b/experimental/rust/stack.yaml
@@ -1,5 +1,5 @@
 name: Rust
-version: 0.1.0 
+version: 0.1.1
 description: Runtime for Rust applications
 license: Apache-2.0
 language: rust


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->
Before we were running `cargo run` to get the executable path, but this is the wrong behavior for `appsody build`. I have changed this so we run `cargo build --release` and recursively look for the built binary instead

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->