### PR TITLE
swift: Initial version of Kitura stack

### DIFF
--- a/incubator/kitura/README.md
+++ b/incubator/kitura/README.md
@@ -1,0 +1,66 @@
+# Kitura Stack
+
+The [Kitura](https://kitura.io) stack extends the [Swift stack](../swift/README.md).  Kitura is an open source web framework for server-side Swift that can be used to build web applications and REST APIs, with full support for databases, WebSockets, OpenAPI and much more.
+
+## Templates
+
+Templates are used to create your local project and start your development. When initializing your project you will be provided with the default template project. This template provides a simple application that hosts the Kitura landing page!
+
+## Getting Started for a new Project
+
+1. Create a new folder in your local directory and initialize it using the Appsody CLI, e.g.:
+
+    ```bash
+    mkdir my-project
+    cd my-project
+    appsody init kitura
+    ```
+    This will initialize a Kitura project using the default template.
+
+2. After your project has been initialized you can then run your application using the following command:
+
+    ```bash
+    appsody run
+    ```
+
+    This launches a Docker container that continuously re-builds and re-runs your project. It also exposes port 8080, to allow you to bring your own web application and use it with this stack.
+
+    You can continue to edit the application in your preferred IDE (VSCode or other) and your changes will be reflected in the running container within a few seconds.
+
+3. If you navigate to http://localhost:8080 you will see the Kitura landing page.
+
+**NOTE:** Currently the `appsody deploy` command only works for deploying web applications.
+
+## Enabling an existing Project
+
+The Kitura stack can be used with an existing Kitura project in order to provide an iterative containerized development and test environment, and to "cloud package" it into an optimized production Docker container.
+
+You can enable an existing project as follows:
+
+1. Go to you project directory, e.g.:
+
+    ```bash
+    cd my-project
+    ```
+
+2. Initialize your Appsody project with the Swift stack, but without a template:
+
+    ```bash
+    appsody init kitura none
+    ```
+
+3. After your project has been initialized you can then run your application using the following command:
+
+    ```bash
+    appsody run
+    ```
+
+    This launches a Docker container that continuously re-builds and re-runs your project. It also exposes port 8080, to allow you to bring your own web application and use it with this stack.
+
+    You can continue to edit the application in your preferred IDE (VSCode or other) and your changes will be reflected in the running container within a few seconds.
+
+3. You should see your application run, with logs written to the console.
+
+## License
+
+This stack is licensed under the [Apache 2.0](./image/LICENSE) license

--- a/incubator/kitura/README.md
+++ b/incubator/kitura/README.md
@@ -4,7 +4,7 @@ The [Kitura](https://kitura.io) stack extends the [Swift stack](../swift/README.
 
 ## Templates
 
-Templates are used to create your local project and start your development. When initializing your project you will be provided with the default template project. This template provides a simple application that hosts the Kitura landing page, and an example route on `/hello` which returns a simple greeting.
+Templates are used to create your local project and start your development. The `default` template provides a simple application that hosts the Kitura landing page, and an example route on `/hello`, that returns a simple greeting.
 
 ## Getting Started for a new Project
 
@@ -15,7 +15,7 @@ Templates are used to create your local project and start your development. When
     cd my-project
     appsody init kitura
     ```
-    This will initialize a Kitura project using the default template.
+    This initializes a Kitura project using the `default` template.
 
 2. After your project has been initialized you can then run your application using the following command:
 
@@ -23,7 +23,7 @@ Templates are used to create your local project and start your development. When
     appsody run
     ```
 
-    This launches a Docker container that continuously re-builds and re-runs your project. It also exposes port 8080, to allow you to interact with your application.
+    This launches a Docker container that rebuilds and reruns your project in response to source code changes. It publishes port 8080, to allow you to interact with your application.
 
     You can continue to edit the application in your preferred IDE (VSCode, Xcode or others) and your changes will be reflected in the running container within a few seconds.
 
@@ -43,7 +43,7 @@ The project's dependencies include `AppsodyKitura`, a package provided by the st
 
 ## Enabling an existing Project
 
-The Kitura stack can be used with an existing Kitura project in order to provide an iterative containerized development and test environment, and to "cloud package" it into an optimized production Docker container.
+This stack can be used with an existing Kitura project to provide an iterative, containerized development and test environment, and to "cloud package" it into an optimized production Docker container.
 
 You can enable an existing project as follows:
 
@@ -69,7 +69,7 @@ You can enable an existing project as follows:
         // Place any additional dependencies here
     ],
     ```
-    Note: AppsodyKitura provides the `Kitura`, `HeliumLogger`, `Kitura-OpenAPI`, `SwiftMetrics` and `Configuration` dependencies. You may remove these dependencies if your existing project declared them.
+    Note: AppsodyKitura provides the `Kitura`, `HeliumLogger`, `Kitura-OpenAPI`, `SwiftMetrics` and `Configuration` dependencies. You can remove these dependencies if your existing project declared them.
 
     In your application's target:
     ```diff
@@ -95,11 +95,11 @@ You can enable an existing project as follows:
     appsody run
     ```
 
-    This launches a Docker container that continuously re-builds and re-runs your project. It also exposes port 8080, to allow you to bring your own web application and use it with this stack.
+    This launches a Docker container that rebuilds and reruns your project in response to source code changes. It publishes port 8080, to allow you to interact with your application.
 
-    You can continue to edit the application in your preferred IDE (VSCode or other) and your changes will be reflected in the running container within a few seconds.
+    You can continue to edit the application in your preferred IDE (VSCode, Xcode or others) and your changes will be reflected in the running container within a few seconds.
 
-3. You should see your application run, with logs written to the console.
+5. You should see your application run, with logs written to the console.
 
 ## Debugging
 

--- a/incubator/kitura/README.md
+++ b/incubator/kitura/README.md
@@ -4,7 +4,7 @@ The [Kitura](https://kitura.io) stack extends the [Swift stack](../swift/README.
 
 ## Templates
 
-Templates are used to create your local project and start your development. The `default` template provides a simple application that hosts the Kitura landing page, and an example route on `/hello`, that returns a simple greeting.
+Templates are used to create your local project and start your development. The `default` template provides a simple application that hosts the Kitura landing page, and an example route on `/hello`, which returns a simple greeting.
 
 ## Getting Started for a new Project
 
@@ -37,7 +37,7 @@ The `kitura` stack provides a number of predefined routes for your application:
 - `/openapi`: the OpenAPI definition for your server, describing all Codable routes
 - `/openapi/ui`: the SwaggerUI allowing you to inspect and test your routes.
 
-The project's dependencies include `AppsodyKitura`, a package provided by the stack that includes the `Kitura`, `HeliumLogger` and `Configuration` packages.  These are available to be imported by your application and you do not need to declare a dependency on them explicitly.
+The project's dependencies include `AppsodyKitura`, a package provided by the stack that includes the `Kitura`, `HeliumLogger` and `Configuration` packages.  These can be imported by your application and you do not need to declare a dependency on them explicitly.
 
 **NOTE:** You should not remove or modify the `AppsodyKitura` dependency.
 

--- a/incubator/kitura/README.md
+++ b/incubator/kitura/README.md
@@ -17,7 +17,7 @@ Templates are used to create your local project and start your development. The 
     ```
     This initializes a Kitura project using the `default` template.
 
-2. After your project has been initialized you can then run your application using the following command:
+2. After your project has been initialized, you can run your application using the following command:
 
     ```bash
     appsody run

--- a/incubator/kitura/README.md
+++ b/incubator/kitura/README.md
@@ -4,7 +4,7 @@ The [Kitura](https://kitura.io) stack extends the [Swift stack](../swift/README.
 
 ## Templates
 
-Templates are used to create your local project and start your development. When initializing your project you will be provided with the default template project. This template provides a simple application that hosts the Kitura landing page!
+Templates are used to create your local project and start your development. When initializing your project you will be provided with the default template project. This template provides a simple application that hosts the Kitura landing page, and an example route on `/hello` which returns a simple greeting.
 
 ## Getting Started for a new Project
 
@@ -23,13 +23,23 @@ Templates are used to create your local project and start your development. When
     appsody run
     ```
 
-    This launches a Docker container that continuously re-builds and re-runs your project. It also exposes port 8080, to allow you to bring your own web application and use it with this stack.
+    This launches a Docker container that continuously re-builds and re-runs your project. It also exposes port 8080, to allow you to interact with your application.
 
-    You can continue to edit the application in your preferred IDE (VSCode or other) and your changes will be reflected in the running container within a few seconds.
+    You can continue to edit the application in your preferred IDE (VSCode, Xcode or others) and your changes will be reflected in the running container within a few seconds.
 
 3. If you navigate to http://localhost:8080 you will see the Kitura landing page.
 
-**NOTE:** Currently the `appsody deploy` command only works for deploying web applications.
+## Facilities provided by the stack
+
+The `kitura` stack provides a number of predefined routes for your application:
+- `/health`: the liveness endpoint
+- `/metrics`: the Prometheus metrics endpoint
+- `/openapi`: the OpenAPI definition for your server, describing all Codable routes
+- `/openapi/ui`: the SwaggerUI allowing you to inspect and test your routes.
+
+The project's dependencies include `AppsodyKitura`, a package provided by the stack that includes the `Kitura`, `HeliumLogger` and `Configuration` packages.  These are available to be imported by your application and you do not need to declare a dependency on them explicitly.
+
+**NOTE:** You should not remove or modify the `AppsodyKitura` dependency.
 
 ## Enabling an existing Project
 
@@ -49,7 +59,37 @@ You can enable an existing project as follows:
     appsody init kitura none
     ```
 
-3. After your project has been initialized you can then run your application using the following command:
+3. Add the `AppsodyKitura` dependency to your `Package.swift`:
+
+In your package dependencies:
+    ```diff
+    dependencies: [
+-      .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.8.0")),
++      .package(path: ".appsody/AppsodyKitura"),
+      // Place any additional dependencies here
+    ],
+    ```
+Note: AppsodyKitura provides the `Kitura`, `HeliumLogger`, `Kitura-OpenAPI`, `SwiftMetrics` and `Configuration` dependencies. You may remove these dependencies if your existing project declared them.
+
+In your application's target:
+    ```diff
+    targets: [
+      .target(name: "my-project", dependencies: [ .target(name: "Application") ]),
+      .target(name: "Application", dependencies: [
++          "AppsodyKitura",
+          // Any additional dependencies
+      ]),
+    ]
+    ```
+
+In your application:
+    ```diff
+-    let router = Router()
++    let router = AppsodyKitura.createRouter()
+    ```
+Note: the router provided by AppsodyKitura is pre-initialized with the liveness, metrics and OpenAPI routes as required by the stack. If your existing application added these routes manually, you must remove them.
+
+4. You can then run your application using the following command:
 
     ```bash
     appsody run
@@ -60,6 +100,26 @@ You can enable an existing project as follows:
     You can continue to edit the application in your preferred IDE (VSCode or other) and your changes will be reflected in the running container within a few seconds.
 
 3. You should see your application run, with logs written to the console.
+
+## Debugging
+
+To debug your application running in a container, start the container using:
+```bash
+appsody debug --docker-options "--cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
+```
+
+You can connect `lldb` in remote debug mode to this container as follows:
+```bash
+lldb \
+  -o "platform select remote-linux" \
+  -o "platform connect connect://localhost:1234" \
+  -o "file .build/debug/server" \
+  -o "env LD_LIBRARY_PATH=/project/user-app/.build/debug"
+```
+
+Once in lldb, you can use `breakpoint set` to set breakpoints in your application, and then `run` to start the app.
+
+**NOTE:** Due to a current limitation, breakpoints must be set _before_ the application is run. Breakpoints can be disabled, but cannot be re-enabled without restarting the app. After adding or re-enabling breakpoints, restart the app with `process kill` and then `run`.
 
 ## License
 

--- a/incubator/kitura/README.md
+++ b/incubator/kitura/README.md
@@ -61,33 +61,33 @@ You can enable an existing project as follows:
 
 3. Add the `AppsodyKitura` dependency to your `Package.swift`:
 
-In your package dependencies:
+    In your package dependencies:
     ```diff
     dependencies: [
--      .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.8.0")),
-+      .package(path: ".appsody/AppsodyKitura"),
-      // Place any additional dependencies here
+    -    .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.8.0")),
+    +    .package(path: ".appsody/AppsodyKitura"),
+        // Place any additional dependencies here
     ],
     ```
-Note: AppsodyKitura provides the `Kitura`, `HeliumLogger`, `Kitura-OpenAPI`, `SwiftMetrics` and `Configuration` dependencies. You may remove these dependencies if your existing project declared them.
+    Note: AppsodyKitura provides the `Kitura`, `HeliumLogger`, `Kitura-OpenAPI`, `SwiftMetrics` and `Configuration` dependencies. You may remove these dependencies if your existing project declared them.
 
-In your application's target:
+    In your application's target:
     ```diff
     targets: [
       .target(name: "my-project", dependencies: [ .target(name: "Application") ]),
       .target(name: "Application", dependencies: [
-+          "AppsodyKitura",
+    +      "AppsodyKitura",
           // Any additional dependencies
       ]),
     ]
     ```
 
-In your application:
+    In your application:
     ```diff
--    let router = Router()
-+    let router = AppsodyKitura.createRouter()
+    -    let router = Router()
+    +    let router = AppsodyKitura.createRouter()
     ```
-Note: the router provided by AppsodyKitura is pre-initialized with the liveness, metrics and OpenAPI routes as required by the stack. If your existing application added these routes manually, you must remove them.
+    Note: the router provided by AppsodyKitura is pre-initialized with the liveness, metrics and OpenAPI routes as required by the stack. If your existing application added these routes manually, you must remove them.
 
 4. You can then run your application using the following command:
 

--- a/incubator/kitura/image/.dockerignore
+++ b/incubator/kitura/image/.dockerignore
@@ -1,0 +1,4 @@
+**/.build
+**/.git
+**/.gitignore
+**/.vscode

--- a/incubator/kitura/image/Dockerfile-stack
+++ b/incubator/kitura/image/Dockerfile-stack
@@ -1,0 +1,38 @@
+FROM appsody/swift:0.1
+
+RUN apt-get update \
+ && apt-get install -y zlib1g-dev libcurl4-openssl-dev libssl-dev \
+ && apt-get clean \
+ && echo 'Finished installing dependencies'
+
+ENV APPSODY_MOUNTS=/:/project/user-app
+ENV APPSODY_DEPS=/project/user-app/.build
+
+ENV APPSODY_WATCH_DIR=/project/user-app
+ENV APPSODY_WATCH_IGNORE_DIR="/project/user-app/.build;/project/user-app/.appsody"
+ENV APPSODY_WATCH_REGEX="^.*.swift$"
+
+ENV APPSODY_INSTALL=""
+
+ENV APPSODY_RUN="swift run"
+ENV APPSODY_RUN_ON_CHANGE="swift run"
+ENV APPSODY_RUN_KILL=true
+
+ENV APPSODY_DEBUG=""
+ENV APPSODY_DEBUG_ON_CHANGE=""
+ENV APPSODY_DEBUG_KILL=true
+
+ENV APPSODY_TEST="swift test"
+ENV APPSODY_TEST_ON_CHANGE=""
+ENV APPSODY_TEST_KILL=false
+
+ENV APPSODY_PROJECT_DIR=/project
+
+COPY ./LICENSE /licenses/
+COPY ./project /project
+COPY ./config /config
+WORKDIR /project/user-app
+
+ENV PORT=8080
+
+EXPOSE 8080

--- a/incubator/kitura/image/Dockerfile-stack
+++ b/incubator/kitura/image/Dockerfile-stack
@@ -12,7 +12,8 @@ ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR="/project/user-app/.build;/project/user-app/.appsody"
 ENV APPSODY_WATCH_REGEX="^.*.swift$"
 
-ENV APPSODY_INSTALL=""
+# Re-copy project dependencies from base image, if they have been modified
+ENV APPSODY_PREP="if [ -n \"$(diff -rq /project/deps /project/user-app/.appsody)\" ]; then rm -rf /project/user-app/.appsody && cp -R -p /project/deps /project/user-app/.appsody; fi"
 
 ENV APPSODY_RUN="swift run"
 ENV APPSODY_RUN_ON_CHANGE="swift run"

--- a/incubator/kitura/image/Dockerfile-stack
+++ b/incubator/kitura/image/Dockerfile-stack
@@ -1,6 +1,10 @@
 FROM appsody/swift:0.1
 
+# Fix Python package layout before installing dependencies. This is a bug in the Swift
+# base image and this workaround should be removed once the base image is corrected.
+# See: https://bugs.swift.org/browse/SR-10344
 RUN apt-get update \
+ && if [ -d "/usr/lib/python2.7/site-packages" ]; then mv /usr/lib/python2.7/site-packages/* /usr/lib/python2.7/dist-packages && rmdir /usr/lib/python2.7/site-packages && ln -s dist-packages /usr/lib/python2.7/site-packages ; fi \
  && apt-get install -y zlib1g-dev libcurl4-openssl-dev libssl-dev \
  && apt-get clean \
  && echo 'Finished installing dependencies'
@@ -19,7 +23,10 @@ ENV APPSODY_RUN="swift run"
 ENV APPSODY_RUN_ON_CHANGE="swift run"
 ENV APPSODY_RUN_KILL=true
 
-ENV APPSODY_DEBUG=""
+# Allow remote debugging. The 'appsody run' command must include the following
+# flag: --docker-options "--cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
+# FIXME: define this in the appropriate Appsody env var once available.
+ENV APPSODY_DEBUG="swift build && export LD_LIBRARY_PATH=/project/user-app/.build/debug && lldb-server platform --listen '*:1234' --min-gdbserver-port 5000 --max-gdbserver-port 5001 --server"
 ENV APPSODY_DEBUG_ON_CHANGE=""
 ENV APPSODY_DEBUG_KILL=true
 
@@ -37,3 +44,5 @@ WORKDIR /project/user-app
 ENV PORT=8080
 
 EXPOSE 8080
+EXPOSE 1234
+EXPOSE 5000

--- a/incubator/kitura/image/LICENSE
+++ b/incubator/kitura/image/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/incubator/kitura/image/config/app-deploy.yaml
+++ b/incubator/kitura/image/config/app-deploy.yaml
@@ -1,0 +1,13 @@
+apiVersion: appsody.dev/v1beta1
+kind: AppsodyApplication
+metadata:
+  name: APPSODY_PROJECT_NAME
+spec:
+  # Add fields here
+  version: 1.0.0
+  applicationImage: APPSODY_DOCKER_IMAGE 
+  stack: APPSODY_STACK
+  service:
+    type: NodePort
+    port: APPSODY_PORT
+  expose: true

--- a/incubator/kitura/image/config/app-deploy.yaml
+++ b/incubator/kitura/image/config/app-deploy.yaml
@@ -12,6 +12,9 @@ spec:
     port: APPSODY_PORT
     annotations:
       prometheus.io/scrape: 'true'
+  monitoring:
+    labels:
+      k8s-app: APPSODY_PROJECT_NAME
   readinessProbe:
     # By default, Kitura's liveness and readiness endpoints are the same.
     # You may wish to implement a custom readiness endpoint that is appropriate for

--- a/incubator/kitura/image/config/app-deploy.yaml
+++ b/incubator/kitura/image/config/app-deploy.yaml
@@ -10,4 +10,24 @@ spec:
   service:
     type: NodePort
     port: APPSODY_PORT
+    annotations:
+      prometheus.io/scrape: 'true'
+  readinessProbe:
+    # By default, Kitura's liveness and readiness endpoints are the same.
+    # You may wish to implement a custom readiness endpoint that is appropriate for
+    # the initialization of your app - if so, adjust the route here.
+    failureThreshold: 12
+    httpGet:
+      path: /health
+      port: APPSODY_PORT
+    initialDelaySeconds: 5
+    periodSeconds: 2
+    timeoutSeconds: 1
+  livenessProbe:
+    failureThreshold: 12
+    httpGet:
+      path: /health
+      port: APPSODY_PORT
+    initialDelaySeconds: 5
+periodSeconds: 2
   expose: true

--- a/incubator/kitura/image/project/.appsody-init.sh
+++ b/incubator/kitura/image/project/.appsody-init.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
+#
+# Create local copy of package dependencies to enable building and code
+# completion while developing locally.
+#
 set -e
 
+# TODO: This should be a reference to the project's stack image
 IMAGE="appsody/kitura"
 
-# Create local copy of package dependencies to enable building locally.
+# Create a temporary container in order to copy files from the stack image
 docker create --name kitura-image-temp $IMAGE >/dev/null
+
+# Current directory is .appsody-init, which is a child of the user's
+# project directory, so we copy the dependencies to a .appsody directory
+# one level up.
 docker cp kitura-image-temp:/project/deps ../.appsody
+
 docker rm kitura-image-temp >/dev/null

--- a/incubator/kitura/image/project/.appsody-init.sh
+++ b/incubator/kitura/image/project/.appsody-init.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+IMAGE="appsody/kitura"
+
+# Create local copy of package dependencies to enable building locally.
+docker create --name kitura-image-temp $IMAGE >/dev/null
+docker cp kitura-image-temp:/project/deps ../.appsody
+docker rm kitura-image-temp >/dev/null

--- a/incubator/kitura/image/project/.appsody-init.sh
+++ b/incubator/kitura/image/project/.appsody-init.sh
@@ -5,15 +5,7 @@
 #
 set -e
 
-# TODO: This should be a reference to the project's stack image
-IMAGE="appsody/kitura"
-
-# Create a temporary container in order to copy files from the stack image
-docker create --name kitura-image-temp $IMAGE >/dev/null
-
 # Current directory is .appsody-init, which is a child of the user's
 # project directory, so we copy the dependencies to a .appsody directory
 # one level up.
-docker cp kitura-image-temp:/project/deps ../.appsody
-
-docker rm kitura-image-temp >/dev/null
+cp -R -p ./deps ../.appsody

--- a/incubator/kitura/image/project/.appsody-init.sh
+++ b/incubator/kitura/image/project/.appsody-init.sh
@@ -9,3 +9,6 @@ set -e
 # project directory, so we copy the dependencies to a .appsody directory
 # one level up.
 cp -R -p ./deps ../.appsody
+
+# Mark dependency source code as read-only
+find ../.appsody -type f -name '*.swift' -exec chmod ugo-w {} \;

--- a/incubator/kitura/image/project/.dockerignore
+++ b/incubator/kitura/image/project/.dockerignore
@@ -1,0 +1,4 @@
+**/.build
+**/.git
+**/.gitignore
+**/.vscode

--- a/incubator/kitura/image/project/Dockerfile
+++ b/incubator/kitura/image/project/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR "/project"
 COPY . /project
 
 # Copy pristine dependencies
+# TODO: This should be a reference to the project's stack image
 RUN rm -rf /project/user-app/.appsody
 COPY --from=appsody/kitura /project/deps /project/user-app/.appsody
 

--- a/incubator/kitura/image/project/Dockerfile
+++ b/incubator/kitura/image/project/Dockerfile
@@ -11,10 +11,9 @@ RUN apt-get update \
 WORKDIR "/project"
 COPY . /project
 
-# Copy pristine dependencies
-# TODO: This should be a reference to the project's stack image
+# Replace dependencies with a pristine copy, in case they have been modified
 RUN rm -rf /project/user-app/.appsody
-COPY --from=appsody/kitura /project/deps /project/user-app/.appsody
+COPY ./deps /project/user-app/.appsody
 
 # Build project, and discover executable name
 WORKDIR "/project/user-app"

--- a/incubator/kitura/image/project/Dockerfile
+++ b/incubator/kitura/image/project/Dockerfile
@@ -1,0 +1,45 @@
+# Install the app dependencies
+FROM swift:5.0 as builder
+
+# Install OS updates
+RUN apt-get update \
+ && apt-get install -y zlib1g-dev libcurl4-openssl-dev libssl-dev \
+ && apt-get clean \
+ && echo 'Finished installing dependencies'
+
+# Copy extracted project
+WORKDIR "/project"
+COPY . /project
+
+# Copy pristine dependencies
+RUN rm -rf /project/user-app/.appsody
+COPY --from=appsody/kitura /project/deps /project/user-app/.appsody
+
+# Build project, and discover executable name
+WORKDIR "/project/user-app"
+RUN echo "#!/bin/bash" > run.sh \
+ && swift build -c release | tee output.txt \
+ && cat output.txt | awk 'END {print $NF}' >> run.sh \
+ && chmod 755 run.sh
+
+FROM swift:5.0-slim
+
+# Install OS updates
+RUN apt-get update \
+ && apt-get clean \
+ && echo 'Finished installing dependencies'
+
+# Define a kitura user
+RUN useradd -ms /bin/bash kitura
+
+# Copy built project
+COPY --chown=kitura:kitura --from=builder /project /project
+
+# Configure listening port
+ENV PORT 8080
+EXPOSE 8080
+
+# Run application as kitura user
+USER kitura
+WORKDIR "/project/user-app"
+CMD ["./run.sh"]

--- a/incubator/kitura/image/project/deps/AppsodyKitura/Package.swift
+++ b/incubator/kitura/image/project/deps/AppsodyKitura/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.0
+import PackageDescription
+
+let package = Package(
+    name: "AppsodyKitura",
+    products: [
+        .library(
+            name: "AppsodyKitura",
+            targets: ["AppsodyKitura"]
+        )
+    ],
+    dependencies: [
+      .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.8.0")),
+      .package(url: "https://github.com/IBM-Swift/HeliumLogger.git", from: "1.9.0"),
+      .package(url: "https://github.com/IBM-Swift/Configuration.git", from: "3.0.0"),
+      .package(url: "https://github.com/RuntimeTools/SwiftMetrics.git", from: "2.0.0"),
+      .package(url: "https://github.com/IBM-Swift/Health.git", from: "1.0.0"),
+    ],
+    targets: [
+      .target(name: "AppsodyKitura", dependencies: [ "Kitura", "HeliumLogger", "Configuration", "SwiftMetrics", "Health" ]),
+      .testTarget(name: "AppsodyKituraTests" , dependencies: [.target(name: "AppsodyKitura"), "Kitura", "HeliumLogger" ])
+    ]
+)

--- a/incubator/kitura/image/project/deps/AppsodyKitura/Package.swift
+++ b/incubator/kitura/image/project/deps/AppsodyKitura/Package.swift
@@ -1,6 +1,10 @@
 // swift-tools-version:5.0
 import PackageDescription
 
+/**
+ * This source file is supplied by the appsody/kitura base image. DO NOT MODIFY.
+ */
+
 let package = Package(
     name: "AppsodyKitura",
     products: [

--- a/incubator/kitura/image/project/deps/AppsodyKitura/Package.swift
+++ b/incubator/kitura/image/project/deps/AppsodyKitura/Package.swift
@@ -19,9 +19,10 @@ let package = Package(
       .package(url: "https://github.com/IBM-Swift/Configuration.git", from: "3.0.0"),
       .package(url: "https://github.com/RuntimeTools/SwiftMetrics.git", from: "2.0.0"),
       .package(url: "https://github.com/IBM-Swift/Health.git", from: "1.0.0"),
+      .package(url: "https://github.com/IBM-Swift/Kitura-OpenAPI.git", from: "1.3.0"),
     ],
     targets: [
-      .target(name: "AppsodyKitura", dependencies: [ "Kitura", "HeliumLogger", "Configuration", "SwiftMetrics", "Health" ]),
+      .target(name: "AppsodyKitura", dependencies: [ "Kitura", "HeliumLogger", "Configuration", "SwiftMetrics", "Health", "KituraOpenAPI" ]),
       .testTarget(name: "AppsodyKituraTests" , dependencies: [.target(name: "AppsodyKitura"), "Kitura", "HeliumLogger" ])
     ]
 )

--- a/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/AppsodyKitura.swift
+++ b/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/AppsodyKitura.swift
@@ -1,3 +1,7 @@
+/**
+ * This source file is supplied by the appsody/kitura base image. DO NOT MODIFY.
+ */
+
 import Foundation
 import Configuration
 import Kitura

--- a/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/AppsodyKitura.swift
+++ b/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/AppsodyKitura.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Configuration
+import Kitura
+
+public class AppsodyKitura {
+
+    static var _manager: ConfigurationManager?
+
+    /// Returns a ConfigurationManager that provides access to environment variables.
+    /// 
+    /// Example:
+    /// ```swift
+    /// let value = manager["MY_VALUE"] as? String ?? "default value"
+    /// ```
+    public static var manager: ConfigurationManager {
+        if let manager = _manager {
+            return manager
+        }
+        let manager = ConfigurationManager()
+        manager.load(.environmentVariables)
+        _manager = manager
+        return manager
+    }
+
+    /// Returns the port that the Kitura server should listen on - this can be
+    /// specified via  the `PORT` environment variable. Defaults to 8080.
+    public static var port: Int {
+        return Int(AppsodyKitura.manager["PORT"] as? String ?? "8080") ?? 8080
+    }
+
+    /// Creates a Kitura `Router` initialized with liveness and metrics endpoints.
+    /// Logging will be enabled at a default level of `info`, which can be customized
+    /// by setting the `LOG_LEVEL` environment variable.
+    public static func createRouter(mergeParameters: Bool = false, enableWelcomePage: Bool = true) -> Router {
+
+        // Configure logging
+        initializeLogging(value: AppsodyKitura.manager["LOG_LEVEL"] as? String)
+
+        let router = Router(mergeParameters: mergeParameters, enableWelcomePage: enableWelcomePage)
+
+        // Run the metrics initializer
+        initializeMetrics(router: router)
+
+        // Add health monitoring endpoint
+        initializeHealthRoutes(router: router)
+
+        return router
+    }
+
+    public static func run(_ router: Router) {
+        Kitura.addHTTPServer(onPort: port, with: router)
+        Kitura.run(exitOnFailure: true)
+    }
+
+}

--- a/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/AppsodyKitura.swift
+++ b/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/AppsodyKitura.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Configuration
 import Kitura
+import KituraOpenAPI
 
 public class AppsodyKitura {
 
@@ -32,7 +33,16 @@ public class AppsodyKitura {
         return Int(AppsodyKitura.manager["PORT"] as? String ?? "8080") ?? 8080
     }
 
-    /// Creates a Kitura `Router` initialized with liveness and metrics endpoints.
+    /// Returns the path configured for serving the OpenAPI document.
+    public static let openAPIPath = "/openapi"
+
+    /// Returns the path configured for serving the Swagger UI tool.
+    public static let swaggerUIPath = "/openapi/ui"
+
+    /// Returns the path configured for serving the liveness (health) endpoint.
+    public static let livenessPath = "/health"
+
+    /// Creates a Kitura `Router` initialized with liveness, metrics and OpenAPI endpoints.
     /// Logging will be enabled at a default level of `info`, which can be customized
     /// by setting the `LOG_LEVEL` environment variable.
     public static func createRouter(mergeParameters: Bool = false, enableWelcomePage: Bool = true) -> Router {
@@ -47,6 +57,10 @@ public class AppsodyKitura {
 
         // Add health monitoring endpoint
         initializeHealthRoutes(router: router)
+
+        // Add OpenAPI endpoints
+        let config = KituraOpenAPIConfig(apiPath: self.openAPIPath, swaggerUIPath: self.swaggerUIPath)
+        KituraOpenAPI.addEndpoints(to: router, with: config)
 
         return router
     }

--- a/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/AppsodyKitura.swift
+++ b/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/AppsodyKitura.swift
@@ -42,6 +42,9 @@ public class AppsodyKitura {
     /// Returns the path configured for serving the liveness (health) endpoint.
     public static let livenessPath = "/health"
 
+    /// Returns the path configured for serving the Prometheus metrics endpoint.
+    public static let metricsPath = "/metrics"
+
     /// Creates a Kitura `Router` initialized with liveness, metrics and OpenAPI endpoints.
     /// Logging will be enabled at a default level of `info`, which can be customized
     /// by setting the `LOG_LEVEL` environment variable.

--- a/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/Logging.swift
+++ b/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/Logging.swift
@@ -1,3 +1,7 @@
+/**
+ * This source file is supplied by the appsody/kitura base image. DO NOT MODIFY.
+ */
+
 import LoggerAPI
 import HeliumLogger
 

--- a/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/Logging.swift
+++ b/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/Logging.swift
@@ -1,0 +1,33 @@
+import LoggerAPI
+import HeliumLogger
+
+/// Initialize logging using HeliumLogger, using the `LOG_LEVEL` environment
+/// variable. This must match the name of a `LoggerMessageType`, or `none` to
+/// disable logging entirely.
+///
+/// If no `LOG_LEVEL` is specified, the default level of `info` will be used.
+///
+func initializeLogging(value: String?) {
+    let logLevel: LoggerMessageType
+    switch value?.lowercased() {
+    case "error":
+        logLevel = .error
+    case "warning":
+        logLevel = .warning
+    case "info":
+        logLevel = .info
+    case "verbose":
+        logLevel = .verbose
+    case "debug":
+        logLevel = .debug
+    case "exit":
+        logLevel = .exit
+    case "entry":
+        logLevel = .entry
+    case "none", "false", "off", "disabled":
+        return
+    default:
+        logLevel = .info
+    }
+    HeliumLogger.use(logLevel)
+}

--- a/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/Metrics.swift
+++ b/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/Metrics.swift
@@ -1,0 +1,28 @@
+import Kitura
+import SwiftMetrics
+import SwiftMetricsDash
+import SwiftMetricsPrometheus
+import SwiftMetricsREST
+import LoggerAPI
+
+var swiftMetrics: SwiftMetrics?
+var swiftMetricsDash: SwiftMetricsDash?
+var swiftMetricsPrometheus: SwiftMetricsPrometheus?
+var swiftMetricsRest: SwiftMetricsREST?
+
+func initializeMetrics(router: Router) {
+    do {
+        let metrics = try SwiftMetrics()
+        let dashboard = try SwiftMetricsDash(swiftMetricsInstance: metrics, endpoint: router)
+        let prometheus = try SwiftMetricsPrometheus(swiftMetricsInstance: metrics, endpoint: router)
+        let rest = try SwiftMetricsREST(swiftMetricsInstance: metrics, endpoint: router)
+
+        swiftMetrics = metrics
+        swiftMetricsDash = dashboard
+        swiftMetricsPrometheus = prometheus
+        swiftMetricsRest = rest
+        Log.info("Initialized metrics.")
+    } catch {
+        Log.warning("Failed to initialize metrics: \(error)")
+    }
+}

--- a/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/Metrics.swift
+++ b/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/Metrics.swift
@@ -1,3 +1,7 @@
+/**
+ * This source file is supplied by the appsody/kitura base image. DO NOT MODIFY.
+ */
+
 import Kitura
 import SwiftMetrics
 import SwiftMetricsDash

--- a/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/Routes/HealthRoutes.swift
+++ b/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/Routes/HealthRoutes.swift
@@ -1,3 +1,7 @@
+/**
+ * This source file is supplied by the appsody/kitura base image. DO NOT MODIFY.
+ */
+
 import Health
 import Kitura
 

--- a/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/Routes/HealthRoutes.swift
+++ b/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/Routes/HealthRoutes.swift
@@ -9,7 +9,7 @@ public let health = Health()
 
 func initializeHealthRoutes(router: Router) {
     
-    router.get("/health") { (respondWith: (Status?, RequestError?) -> Void) -> Void in
+    router.get(AppsodyKitura.livenessPath) { (respondWith: (Status?, RequestError?) -> Void) -> Void in
         if health.status.state == .UP {
             respondWith(health.status, nil)
         } else {

--- a/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/Routes/HealthRoutes.swift
+++ b/incubator/kitura/image/project/deps/AppsodyKitura/Sources/AppsodyKitura/Routes/HealthRoutes.swift
@@ -1,0 +1,16 @@
+import Health
+import Kitura
+
+public let health = Health()
+
+func initializeHealthRoutes(router: Router) {
+    
+    router.get("/health") { (respondWith: (Status?, RequestError?) -> Void) -> Void in
+        if health.status.state == .UP {
+            respondWith(health.status, nil)
+        } else {
+            respondWith(nil, RequestError(.serviceUnavailable, body: health.status))
+        }
+    }
+    
+}

--- a/incubator/kitura/image/project/deps/AppsodyKitura/Tests/AppsodyKituraTests/RouteTests.swift
+++ b/incubator/kitura/image/project/deps/AppsodyKitura/Tests/AppsodyKituraTests/RouteTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Kitura
+import KituraNet
+import XCTest
+
+@testable import AppsodyKitura
+
+class RouteTests: XCTestCase {
+    static var allTests : [(String, (RouteTests) -> () throws -> Void)] {
+        return [
+            ("testGetWelcomePage", testGetWelcomePage),
+            ("testHealthRoute", testHealthRoute)
+        ]
+    }
+
+    let app = App()
+
+    /// Starts the Kitura server using the App's port and router
+    override func setUp() {
+        super.setUp()
+        let server = Kitura.addHTTPServer(onPort: app.port, with: app.router)
+        let startedExpectation = expectation(description: "Server started")
+        server.started {
+            startedExpectation.fulfill()
+        }
+        let failures = Kitura.startWithStatus()
+        XCTAssertEqual(failures, 0)
+        waitForExpectations(timeout: 3.0)
+    }
+
+    /// Stops the Kitura server
+    override func tearDown() {
+        Kitura.stop()
+        super.tearDown()
+    }
+
+    /// Tests that the default welcome page served by Kitura can be obtained.
+    func testGetWelcomePage() {
+        let responseExpectation = expectation(description: "The / route will serve static HTML content.")
+
+        URLRequest(forTestWithMethod: "GET", port: app.port, route: "/")?
+            .responseFromKitura { responseString, statusCode in
+                XCTAssertEqual(statusCode, .OK)
+                guard let responseString = responseString else {
+                    XCTFail("No response string returned")
+                    return responseExpectation.fulfill()
+                }
+                XCTAssertTrue(responseString.contains("<html"))
+                XCTAssertTrue(responseString.contains("</html>"))
+                responseExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 3.0)
+    }
+
+    /// Tests that the built-in health endpoint is responding correctly.
+    func testHealthRoute() {
+        let responseExpectation = expectation(description: "The /health route responds with UP, followed by a timestamp.")
+        
+        URLRequest(forTestWithMethod: "GET", port: app.port, route: "/health")?
+            .responseFromKitura { responseString, statusCode in
+                XCTAssertEqual(statusCode, .OK)
+                guard let responseString = responseString else {
+                    XCTFail("No response string returned")
+                    return responseExpectation.fulfill()
+                }
+                XCTAssertTrue(responseString.contains("UP"), "Health status does not contain 'UP'.")
+                let date = Date()
+                let calendar = Calendar.current
+                let yearString = String(describing: calendar.component(.year, from: date))
+                XCTAssertTrue(responseString.contains(yearString), "Health timestamp does not contain the current year.")
+                responseExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 3.0)
+    }
+
+}
+
+/// A simple HTTP client for use by the application tests.
+private extension URLRequest {
+
+    /// Creates a URLRequest with the specified method, server port and route. It is assumed
+    /// that the server address is `localhost`.
+    /// The `Content-Type` will be set to `application/json`, and a (JSON) message
+    /// body may be supplied as a Data, suitable for testing PUT/POST routes.
+    init?(forTestWithMethod method: String, port: Int, route: String, body: Data? = nil) {
+        let urlString = "http://localhost:" + String(port) + route
+        if let url = URL(string: urlString) {
+            self.init(url: url)
+            addValue("application/json", forHTTPHeaderField: "Content-Type")
+            httpMethod = method
+            cachePolicy = .reloadIgnoringCacheData
+            if let body = body {
+                httpBody = body
+            }
+        } else {
+            XCTFail("Failed to create URL from string '\(urlString)'")
+            return nil
+        }
+    }
+
+    /// Makes a request to Kitura and calls a completion handler with the response body
+    /// (if any) as a String, and the HTTP status code.  If no data is returned, the String will
+    /// be empty.
+    /// If a non-success status is returned, details of the response will also be printed.
+    func responseFromKitura(completion: @escaping (String?, HTTPStatusCode) -> Void) {
+        guard let method = httpMethod, var path = url?.path, let headers = allHTTPHeaderFields else {
+            XCTFail("Invalid request params")
+            return
+        }
+
+        if let query = url?.query {
+            path += "?" + query
+        }
+
+        let requestOptions: [ClientRequest.Options] = [.method(method), .hostname("localhost"), .port(8080), .path(path), .headers(headers)]
+
+        // Create a ClientRequest. Completion will be called when the server
+        // responds.
+        let req = HTTP.request(requestOptions) { response in
+            guard let response = response else {
+                return XCTFail("ClientResponse was nil")
+            }
+            var body = Data()
+            do {
+                try response.readAllData(into: &body)
+            } catch {
+                XCTFail("Failed to read response data: \(error)")
+            }
+            let responseString = String(data: body, encoding: .utf8)
+            if responseString == nil {
+                XCTFail("Unable to decode string from response data")
+            }
+            if response.statusCode.class != .successful {
+                print("Non-success status code: \(response.statusCode)")
+                if let str = responseString, str.count > 0 {
+                    print("Response data: " + str)
+                }
+            }
+            completion(responseString, response.statusCode)
+        }
+
+        // Send request to server
+        if let dataBody = httpBody {
+            req.end(dataBody)
+        } else {
+            req.end()
+        }
+    }
+}

--- a/incubator/kitura/image/project/deps/AppsodyKitura/Tests/LinuxMain.swift
+++ b/incubator/kitura/image/project/deps/AppsodyKitura/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+@testable import KituraAppsodyTests
+
+XCTMain([
+    testCase(RouteTests.allTests),
+    ])

--- a/incubator/kitura/stack.yaml
+++ b/incubator/kitura/stack.yaml
@@ -7,4 +7,7 @@ maintainers:
   - name: Ian Partridge
     email: i.partridge@uk.ibm.com
     github-id: ianpartridge
+  - name: David Jones
+    email: djones6@uk.ibm.com
+    github-id: djones6
 default-template: default

--- a/incubator/kitura/stack.yaml
+++ b/incubator/kitura/stack.yaml
@@ -1,0 +1,10 @@
+name: Kitura
+version: 0.1.0
+description: Runtime for Kitura applications
+license: Apache-2.0
+language: swift
+maintainers:
+  - name: Ian Partridge
+    email: i.partridge@uk.ibm.com
+    github-id: ianpartridge
+default-template: default

--- a/incubator/kitura/templates/default/.gitignore
+++ b/incubator/kitura/templates/default/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+/.build
+/Packages
+*.xcodeproj
+.swiftpm

--- a/incubator/kitura/templates/default/Package.swift
+++ b/incubator/kitura/templates/default/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:5.0
+import PackageDescription
+
+let package = Package(
+    name: "server",
+    dependencies: [
+      .package(path: ".appsody/AppsodyKitura"),
+    ],
+    targets: [
+      .target(name: "server", dependencies: [ .target(name: "Application") ]),
+      .target(name: "Application", dependencies: [ "AppsodyKitura" ]),
+      .testTarget(name: "ApplicationTests" , dependencies: [.target(name: "Application"), "AppsodyKitura" ])
+    ]
+)

--- a/incubator/kitura/templates/default/Sources/Application/Application.swift
+++ b/incubator/kitura/templates/default/Sources/Application/Application.swift
@@ -1,0 +1,27 @@
+import AppsodyKitura
+import Configuration
+import Kitura
+
+public let projectPath = ConfigurationManager.BasePath.project.path
+
+public class App {
+    let router: Router
+    let manager: ConfigurationManager
+
+    public init() {
+        self.router = AppsodyKitura.createRouter()
+        self.manager = AppsodyKitura.manager
+    }
+
+    public func setUpRoutes() {
+        router.get("/hello") { request, response, next in
+            response.send("Hello, World!")
+            next()
+        }
+    }
+
+    public func run() {
+        AppsodyKitura.run(self.router)
+    }
+
+}

--- a/incubator/kitura/templates/default/Sources/server/main.swift
+++ b/incubator/kitura/templates/default/Sources/server/main.swift
@@ -1,0 +1,5 @@
+import Application
+
+let app = App()
+app.setUpRoutes()
+app.run()

--- a/incubator/kitura/templates/default/Tests/ApplicationTests/RouteTests.swift
+++ b/incubator/kitura/templates/default/Tests/ApplicationTests/RouteTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Kitura
+import KituraNet
+import XCTest
+import AppsodyKitura
+
+@testable import Application
+
+class RouteTests: XCTestCase {
+    static var allTests : [(String, (RouteTests) -> () throws -> Void)] {
+        return [
+            ("testGetWelcomePage", testGetWelcomePage),
+            ("testHealthRoute", testHealthRoute)
+        ]
+    }
+
+    let app = App()
+
+    /// Starts the Kitura server using the App's port and router
+    override func setUp() {
+        super.setUp()
+        let server = Kitura.addHTTPServer(onPort: AppsodyKitura.port, with: app.router)
+        let startedExpectation = expectation(description: "Server started")
+        server.started {
+            startedExpectation.fulfill()
+        }
+        let failures = Kitura.startWithStatus()
+        XCTAssertEqual(failures, 0)
+        waitForExpectations(timeout: 3.0)
+    }
+
+    /// Stops the Kitura server
+    override func tearDown() {
+        Kitura.stop()
+        super.tearDown()
+    }
+
+    /// Tests that the default welcome page served by Kitura can be obtained.
+    func testGetWelcomePage() {
+        let responseExpectation = expectation(description: "The / route will serve static HTML content.")
+
+        URLRequest(forTestWithMethod: "GET", port: AppsodyKitura.port, route: "/")?
+            .responseFromKitura { responseString, statusCode in
+                XCTAssertEqual(statusCode, .OK)
+                guard let responseString = responseString else {
+                    XCTFail("No response string returned")
+                    return responseExpectation.fulfill()
+                }
+                XCTAssertTrue(responseString.contains("<html"))
+                XCTAssertTrue(responseString.contains("</html>"))
+                responseExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 3.0)
+    }
+
+    /// Tests that the built-in health endpoint is responding correctly.
+    func testHealthRoute() {
+        let responseExpectation = expectation(description: "The /health route responds with UP, followed by a timestamp.")
+        
+        URLRequest(forTestWithMethod: "GET", port: AppsodyKitura.port, route: "/health")?
+            .responseFromKitura { responseString, statusCode in
+                XCTAssertEqual(statusCode, .OK)
+                guard let responseString = responseString else {
+                    XCTFail("No response string returned")
+                    return responseExpectation.fulfill()
+                }
+                XCTAssertTrue(responseString.contains("UP"), "Health status does not contain 'UP'.")
+                let date = Date()
+                let calendar = Calendar.current
+                let yearString = String(describing: calendar.component(.year, from: date))
+                XCTAssertTrue(responseString.contains(yearString), "Health timestamp does not contain the current year.")
+                responseExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 3.0)
+    }
+
+}
+
+/// A simple HTTP client for use by the application tests.
+private extension URLRequest {
+
+    /// Creates a URLRequest with the specified method, server port and route. It is assumed
+    /// that the server address is `localhost`.
+    /// The `Content-Type` will be set to `application/json`, and a (JSON) message
+    /// body may be supplied as a Data, suitable for testing PUT/POST routes.
+    init?(forTestWithMethod method: String, port: Int, route: String, body: Data? = nil) {
+        let urlString = "http://localhost:" + String(port) + route
+        if let url = URL(string: urlString) {
+            self.init(url: url)
+            addValue("application/json", forHTTPHeaderField: "Content-Type")
+            httpMethod = method
+            cachePolicy = .reloadIgnoringCacheData
+            if let body = body {
+                httpBody = body
+            }
+        } else {
+            XCTFail("Failed to create URL from string '\(urlString)'")
+            return nil
+        }
+    }
+
+    /// Makes a request to Kitura and calls a completion handler with the response body
+    /// (if any) as a String, and the HTTP status code.  If no data is returned, the String will
+    /// be empty.
+    /// If a non-success status is returned, details of the response will also be printed.
+    func responseFromKitura(completion: @escaping (String?, HTTPStatusCode) -> Void) {
+        guard let url = url else {
+            return XCTFail("URL is nil")
+        }
+        guard let method = httpMethod, let headers = allHTTPHeaderFields, let host = url.host, let port = url.port else {
+            return XCTFail("Invalid request params")
+        }
+
+        var path = url.path
+        if let query = url.query {
+            path += "?" + query
+        }
+
+        let requestOptions: [ClientRequest.Options] = [.method(method), .hostname(host), .port(Int16(bitPattern: UInt16(port))), .path(path), .headers(headers)]
+
+        // Create a ClientRequest. Completion will be called when the server
+        // responds.
+        let req = HTTP.request(requestOptions) { response in
+            guard let response = response else {
+                return XCTFail("ClientResponse was nil for \(method) on \(host):\(port)/\(path)")
+            }
+            var body = Data()
+            do {
+                try response.readAllData(into: &body)
+            } catch {
+                XCTFail("Failed to read response data: \(error)")
+            }
+            let responseString = String(data: body, encoding: .utf8)
+            if responseString == nil {
+                XCTFail("Unable to decode string from response data")
+            }
+            if response.statusCode.class != .successful {
+                print("Non-success status code: \(response.statusCode)")
+                if let str = responseString, str.count > 0 {
+                    print("Response data: " + str)
+                }
+            }
+            completion(responseString, response.statusCode)
+        }
+
+        // Send request to server
+        if let dataBody = httpBody {
+            req.end(dataBody)
+        } else {
+            req.end()
+        }
+    }
+}

--- a/incubator/kitura/templates/default/Tests/LinuxMain.swift
+++ b/incubator/kitura/templates/default/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+@testable import ApplicationTests
+
+XCTMain([
+    testCase(RouteTests.allTests),
+    ])

--- a/incubator/kitura/templates/default/Tests/LinuxMain.swift
+++ b/incubator/kitura/templates/default/Tests/LinuxMain.swift
@@ -3,5 +3,5 @@ import XCTest
 @testable import ApplicationTests
 
 XCTMain([
-    testCase(RouteTests.allTests),
+    testCase(KituraStackTests.allTests),
     ])


### PR DESCRIPTION
A new stack, based on top of the `appsody/swift` stack, suitable for developing a Kitura application.  Metrics and health endpoints are baked in to the stack.

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).

### Contributing a new stack:

- Describe how application dependencies are managed:

The template's application's dependencies are provided by a Swift package called `AppsodyKitura`. This package in turn depends on `Kitura`, `SwiftMetrics` and the other Swift packages required to build a Kitura app.

AppsodyKitura is provided as a local Swift package in the base image.  In order to allow local builds and functioning code completion in IDEs (eg. Xcode), the dependencies are copied into the user's local directory under a `.appsody` subdirectory.  This code is replaced during `appsody build` with a pristine copy of the dependencies.

As there is nothing technically preventing the user from modifying AppsodyKitura locally, warnings are present at the top of the source files not to modify them (as such modifications would not appear in the production image).  The sources are marked read-only to avoid unintentional edits (Xcode will put up a warning about 'unlocking' read-only files).

- Explain how Appsody file watcher is utilized:

The file watcher watches for changes to any `.swift` files.

The `.build` and `.appsody` directories are excluded, as these contain the Swift package dependencies (including source code).

- Describe other Appsody environment variables defined by the stack image:

`APPSODY_DEPS` is used to persist the `user-app/.build` directory to provide incremental builds, and cache the Swift package dependencies (since these exist within `.build/checkouts`).

- Describe any limitations and known issues:

Debugging support is not implemented yet.  The requirements are similar to Rust (#429), so debug support can be replicated here once that solution has been implemented.

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->