### PR TITLE
ci: Update fallback cli version to 0.4.7

### DIFF
--- a/ci/ext/pre_test.d/10_travis
+++ b/ci/ext/pre_test.d/10_travis
@@ -13,7 +13,7 @@ then
     fi
     if [ -z "${APPSODY_CLI_FALLBACK}" ]
     then
-        APPSODY_CLI_FALLBACK=0.4.2
+        APPSODY_CLI_FALLBACK=0.4.7
     fi
 
     cli_dir=$build_dir/cli


### PR DESCRIPTION
Update fallback cli version to 0.4.7

Signed-off-by Neeraj Laad <neeraj.laad@gmail.com>

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
