### PR TITLE
Update kitura stack to Kitura 2.9 and Swift 5.1

### DIFF
--- a/incubator/kitura/README.md
+++ b/incubator/kitura/README.md
@@ -64,7 +64,7 @@ You can enable an existing project as follows:
     In your package dependencies:
     ```diff
     dependencies: [
-    -    .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.8.0")),
+    -    .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.9.0")),
     +    .package(path: ".appsody/AppsodyKitura"),
         // Place any additional dependencies here
     ],
@@ -103,6 +103,10 @@ You can enable an existing project as follows:
 
 ## Debugging
 
+You can debug your application running in an appsody container using lldb.
+
+### Debugging from the command line
+
 To debug your application running in a container, start the container using:
 ```bash
 appsody debug --docker-options "--cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
@@ -120,6 +124,18 @@ lldb \
 Once in lldb, you can use `breakpoint set` to set breakpoints in your application, and then `run` to start the app.
 
 **NOTE:** Due to a current limitation, breakpoints must be set _before_ the application is run. Breakpoints can be disabled, but cannot be re-enabled without restarting the app. After adding or re-enabling breakpoints, restart the app with `process kill` and then `run`.
+
+### Debugging from VSCode
+
+You can debug directly through VSCode as follows:
+- Install the [CodeLLDB](https://github.com/vadimcn/vscode-lldb.git) plugin.
+- Run the `Appsody: debug` task provided.
+- Set any breakpoints that you require in your code.
+- From the Debug view, run the `Remote Debug` configuration.
+
+The final step connects the debugger to your appsody container and launches an instance of your app. Upon hitting a breakpoint, you will see the application's state in VSCode's debug view.
+
+**NOTE:** Due to a current limitation, restarting the debugger will fail. To restart the debugging session, first restart the appsody container. You can do this by running the `Appsody: stop` and `Appsody: debug` tasks.
 
 ## License
 

--- a/incubator/kitura/image/Dockerfile-stack
+++ b/incubator/kitura/image/Dockerfile-stack
@@ -23,7 +23,7 @@ ENV APPSODY_RUN="swift run"
 ENV APPSODY_RUN_ON_CHANGE="swift run"
 ENV APPSODY_RUN_KILL=true
 
-# Allow remote debugging. The 'appsody run' command must include the following
+# Allow remote debugging. The 'appsody debug' command must include the following
 # flag: --docker-options "--cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
 # FIXME: define this in the appropriate Appsody env var once available.
 ENV APPSODY_DEBUG="swift build && export LD_LIBRARY_PATH=/project/user-app/.build/debug && lldb-server platform --listen '*:1234' --min-gdbserver-port 5000 --max-gdbserver-port 5001 --server"

--- a/incubator/kitura/image/Dockerfile-stack
+++ b/incubator/kitura/image/Dockerfile-stack
@@ -1,4 +1,4 @@
-FROM appsody/swift:0.1
+FROM appsody/swift:0.2
 
 # Fix Python package layout before installing dependencies. This is a bug in the Swift
 # base image and this workaround should be removed once the base image is corrected.
@@ -27,8 +27,8 @@ ENV APPSODY_RUN_KILL=true
 # flag: --docker-options "--cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
 # FIXME: define this in the appropriate Appsody env var once available.
 ENV APPSODY_DEBUG="swift build && export LD_LIBRARY_PATH=/project/user-app/.build/debug && lldb-server platform --listen '*:1234' --min-gdbserver-port 5000 --max-gdbserver-port 5001 --server"
-ENV APPSODY_DEBUG_ON_CHANGE=""
-ENV APPSODY_DEBUG_KILL=true
+ENV APPSODY_DEBUG_ON_CHANGE="swift build"
+ENV APPSODY_DEBUG_KILL=false
 
 ENV APPSODY_TEST="swift test"
 ENV APPSODY_TEST_ON_CHANGE=""

--- a/incubator/kitura/image/Dockerfile-stack
+++ b/incubator/kitura/image/Dockerfile-stack
@@ -26,8 +26,8 @@ ENV APPSODY_RUN_KILL=true
 # Allow remote debugging. The 'appsody debug' command must include the following
 # flag: --docker-options "--cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
 # FIXME: define this in the appropriate Appsody env var once available.
-ENV APPSODY_DEBUG="swift build && export LD_LIBRARY_PATH=/project/user-app/.build/debug && lldb-server platform --listen '*:1234' --min-gdbserver-port 5000 --max-gdbserver-port 5001 --server"
-ENV APPSODY_DEBUG_ON_CHANGE="swift build"
+ENV APPSODY_DEBUG="swift build && echo \"Ready to debug\" && lldb-server platform --listen '*:1234' --min-gdbserver-port 5000 --max-gdbserver-port 5001 --server"
+ENV APPSODY_DEBUG_ON_CHANGE="swift build && echo \"Ready to debug\""
 ENV APPSODY_DEBUG_KILL=false
 
 ENV APPSODY_TEST="swift test"

--- a/incubator/kitura/image/project/Dockerfile
+++ b/incubator/kitura/image/project/Dockerfile
@@ -1,5 +1,5 @@
 # Install the app dependencies
-FROM swift:5.0 as builder
+FROM swift:5.1 as builder
 
 # Install OS updates
 RUN apt-get update \
@@ -22,7 +22,7 @@ RUN echo "#!/bin/bash" > run.sh \
  && cat output.txt | awk 'END {print $NF}' >> run.sh \
  && chmod 755 run.sh
 
-FROM swift:5.0-slim
+FROM swift:5.1-slim
 
 # Install OS updates
 RUN apt-get update \

--- a/incubator/kitura/image/project/deps/AppsodyKitura/Package.swift
+++ b/incubator/kitura/image/project/deps/AppsodyKitura/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 import PackageDescription
 
 /**
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-      .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.8.0")),
+      .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.9.0")),
       .package(url: "https://github.com/IBM-Swift/HeliumLogger.git", from: "1.9.0"),
       .package(url: "https://github.com/IBM-Swift/Configuration.git", from: "3.0.0"),
       .package(url: "https://github.com/RuntimeTools/SwiftMetrics.git", from: "2.0.0"),

--- a/incubator/kitura/stack.yaml
+++ b/incubator/kitura/stack.yaml
@@ -1,5 +1,5 @@
 name: Kitura
-version: 0.1.0
+version: 0.2.0
 description: Runtime for Kitura applications
 license: Apache-2.0
 language: swift

--- a/incubator/kitura/templates/default/.vscode/launch.json
+++ b/incubator/kitura/templates/default/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // This configuration requires the CodeLLDB plugin:
+            // https://github.com/vadimcn/vscode-lldb
+            "name": "Remote Debug",
+            "type": "lldb",
+            "request": "custom",
+            "initCommands": [
+                "platform select remote-linux",
+                "platform connect connect://localhost:1234",
+                "env LD_LIBRARY_PATH=/project/user-app/.build/debug"
+            ],
+            "targetCreateCommands": [
+                "file .build/x86_64-unknown-linux/debug/server"
+            ],
+            "processCreateCommands": [
+                "run"
+            ],
+            "sourceMap": { "/project/user-app" : "${workspaceFolder}" },
+            "exitCommands": [
+                "process kill"
+            ]
+        }
+    ]
+}

--- a/incubator/kitura/templates/default/.vscode/tasks.json
+++ b/incubator/kitura/templates/default/.vscode/tasks.json
@@ -1,0 +1,47 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Appsody: run",
+            "type": "shell",
+            "command": "appsody run",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "Appsody: debug",
+            "type": "shell",
+            "command": "appsody debug --docker-options \"--cap-add=SYS_PTRACE --security-opt seccomp=unconfined\"",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "Appsody: test",
+            "type": "shell",
+            "command": "appsody test",
+            "group": "test",
+            "problemMatcher": []
+        },
+        {
+            "label": "Appsody: build",
+            "type": "shell",
+            "command": "appsody build",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "Appsody: deploy",
+            "type": "shell",
+            "command": "appsody deploy",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "Appsody: stop",
+            "type": "shell",
+            "command": "appsody stop",
+            "group": "build",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/incubator/kitura/templates/default/Package.swift
+++ b/incubator/kitura/templates/default/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
Updates the `incubator/kitura` stack to use Swift 5.1, and updates the Kitura version to 2.9.

Also adds debugging configuration for VSCode as well as a copy of the VSCode tasks defined in the swift stack.

Note: depends on updated Swift stack (#444)

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ ] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->