### PR TITLE
Correction to image tag - appsody-quarkus:latest

### DIFF
--- a/experimental/quarkus/README.md
+++ b/experimental/quarkus/README.md
@@ -57,7 +57,7 @@ To try this, run:
 
 ```bash
 appsody build
-docker run -i --rm -p 8080:8080 my-project:latest
+docker run -i --rm -p 8080:8080 <my-project>:latest
 ```
 
 Running the production container should give you an output similar to:

--- a/experimental/quarkus/README.md
+++ b/experimental/quarkus/README.md
@@ -57,7 +57,7 @@ To try this, run:
 
 ```bash
 appsody build
-docker run -i --rm -p 8080:8080 appsody-quarkus:latest
+docker run -i --rm -p 8080:8080 my-project:latest
 ```
 
 Running the production container should give you an output similar to:

--- a/experimental/quarkus/README.md
+++ b/experimental/quarkus/README.md
@@ -57,7 +57,7 @@ To try this, run:
 
 ```bash
 appsody build
-docker run -i --rm -p 8080:8080 default:latest
+docker run -i --rm -p 8080:8080 appsody-quarkus:latest
 ```
 
 Running the production container should give you an output similar to:


### PR DESCRIPTION
Correction to image tag - appsody-quarkus:latest; not default:latest

For "appsody build" command on "quarkus" stack, the image is tagged as "appsody-quarkus:latest"
...
...
[Docker] Successfully tagged appsody-quarkus:latest
...
...
Running "docker run...." command for "default:latest" yields 

`"Unable` to find image 'default:latest' locally
docker: Error response from daemon: pull access denied for default, repository does not exist or may require 'docker login': denied: requested access to the resource is denied." `

Hence, creating PR to update GitHub documentation from "default:latest" to appsody-quarkus:latest

### Checklist:

- [ ] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ ] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->