### PR TITLE
Vertx: Updated stack.yaml to use SPDX license id instead of long name

### DIFF
--- a/experimental/vertx/image/project/pom.xml
+++ b/experimental/vertx/image/project/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>dev.appsody</groupId>
     <artifactId>vertx</artifactId>
-    <version>0.1.3</version>
+    <version>0.1.4</version>
     <packaging>pom</packaging>
 
   <properties>

--- a/experimental/vertx/stack.yaml
+++ b/experimental/vertx/stack.yaml
@@ -1,7 +1,7 @@
 name: Eclipse Vert.x
-version: 0.1.3
+version: 0.1.4
 description: Eclipse Vert.x runtime for running Java applications
-license: Eclipse Public License - Version 2.0
+license: EPL-2.0
 language: java
 maintainers:
   - name: Erik Jan de Wit


### PR DESCRIPTION
Updated stack.yaml to use appropriate SPDX License ID vs using the full license name.

Signed-off-by Neeraj Laad <neeraj.laad@gmail.com>

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

Current `stack.yaml` was using a long name for license field and that includes characters that are not allowed as image or k8s label value. Updated the file to use the equivalent license ID. 