### PR TITLE
swift: fix deploy

### DIFF
--- a/incubator/swift/image/Dockerfile-stack
+++ b/incubator/swift/image/Dockerfile-stack
@@ -7,6 +7,7 @@ RUN apt-get update \
 
 ENV APPSODY_MOUNTS=/:/project/user-app
 ENV APPSODY_DEPS=/project/user-app/.build
+ENV APPSODY_PROJECT_DIR=/project
 
 ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/.build

--- a/incubator/swift/image/project/Dockerfile
+++ b/incubator/swift/image/project/Dockerfile
@@ -12,9 +12,9 @@ WORKDIR "/project/user-app"
 COPY ./user-app ./
 
 # Build project, and discover executable name
-RUN echo "#!/bin/bash" > run.sh \
+RUN echo '#!/bin/bash' > run.sh \
  && swift build -c release | tee output.txt \
- && cat output.txt | awk 'END {print $NF}' >> run.sh \
+ && cat output.txt | awk 'END {print "./.build/x86_64-unknown-linux/release/" $NF}' >> run.sh \
  && chmod 755 run.sh
 
 FROM swift:5.1-slim

--- a/incubator/swift/stack.yaml
+++ b/incubator/swift/stack.yaml
@@ -1,5 +1,5 @@
 name: Swift
-version: 0.2.0
+version: 0.2.1
 description: Runtime for Swift applications
 license: Apache-2.0
 language: swift


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

#### Fix warning

Fix CLI warning when using the `swift` stack by defining `APPSODY_PROJECT_DIR`:

```
[Warning] The stack image does not contain APPSODY_PROJECT_DIR. Using /project
```

#### Fix deploy

Swift 5.1 changes the compiler output so it no longer includes the relative path to the build executable. Update the deploy `Dockerfile` to add the correct path to `run.sh` so that the built Docker image can be successfully deployed to k8s.