### PR TITLE
swift: override Docker labels from base image

### DIFF
--- a/incubator/swift/image/Dockerfile-stack
+++ b/incubator/swift/image/Dockerfile-stack
@@ -1,5 +1,8 @@
 FROM swift:5.1
 
+LABEL Description="Appsody runtime for Swift applications"
+LABEL maintainer="Ian Partridge <i.partridge@uk.ibm.com>, David Jones <djones6@uk.ibm.com>"
+
 RUN apt-get update \
  && apt-get install -y zlib1g-dev libcurl4-openssl-dev libssl-dev \
  && apt-get clean \

--- a/incubator/swift/stack.yaml
+++ b/incubator/swift/stack.yaml
@@ -1,6 +1,6 @@
 name: Swift
-version: 0.2.1
-description: Runtime for Swift applications
+version: 0.2.2
+description: Appsody runtime for Swift applications
 license: Apache-2.0
 language: swift
 maintainers:


### PR DESCRIPTION
The base `swift:5.1` Docker image defines two labels: `Description`
and `maintainer`. These were being propagated through to the
`appsody/swift` images, which was misleading as the wrong maintainer was
listed in our image.

Override these labels in the Swift stack's `Dockerfile-stack` so that
the correct information appears in `docker describe` output.