### PR TITLE
[python-flask] Ensure liveness port is exposed

### DIFF
--- a/incubator/python-flask/image/Dockerfile-stack
+++ b/incubator/python-flask/image/Dockerfile-stack
@@ -40,9 +40,9 @@ RUN python -m pip install ptvsd -t /project/deps
 # This constraints workaround will still cause an error on docker build, but this can be ignored.
 RUN python -m pip install -c constraints.txt flasgger==0.9.3
 
-# ENV PORT=8080
 ENV PYTHONPATH=/project/deps
 ENV FLASK_APP=/project/server/__init__.py
 
+ENV PORT=8080
 EXPOSE 8080
 EXPOSE 5678

--- a/incubator/python-flask/image/project/Dockerfile
+++ b/incubator/python-flask/image/project/Dockerfile
@@ -21,6 +21,6 @@ RUN python -m pip install -r requirements.txt -t /project/deps
 ENV PYTHONPATH=/project/deps
 ENV FLASK_APP=server/__init__.py
 
+ENV PORT=8080
 EXPOSE 8080
-EXPOSE 5678
 CMD ["python", "-m", "flask", "run", "--host=0.0.0.0", "--port=8080"]

--- a/incubator/python-flask/image/project/Dockerfile
+++ b/incubator/python-flask/image/project/Dockerfile
@@ -22,4 +22,5 @@ ENV PYTHONPATH=/project/deps
 ENV FLASK_APP=server/__init__.py
 
 EXPOSE 8080
+EXPOSE 5678
 CMD ["python", "-m", "flask", "run", "--host=0.0.0.0", "--port=8080"]

--- a/incubator/python-flask/stack.yaml
+++ b/incubator/python-flask/stack.yaml
@@ -1,5 +1,5 @@
 name: Python Flask
-version: 0.1.5
+version: 0.1.6
 description: Flask web Framework for Python
 language: python
 maintainers:


### PR DESCRIPTION
Expose the liveness port in the application docker file (it was only being exposed in the stack docker file). Without this,  k8s  would consider the pod to be dead.

Fixes #461