### PR TITLE
swift: bump stack version for Swift 5.1.2

### DIFF
--- a/incubator/swift/README.md
+++ b/incubator/swift/README.md
@@ -2,7 +2,7 @@
 
 The Swift stack is designed to provide a foundation for building and running Swift applications in Appsody.
 
-This stack is based on the `Swift 5.0` runtime and allows you to develop new or existing Swift applications using Appsody.
+This stack is based on the `Swift 5.1` runtime and allows you to develop new or existing Swift applications using Appsody.
 
 ## Templates
 

--- a/incubator/swift/stack.yaml
+++ b/incubator/swift/stack.yaml
@@ -1,5 +1,5 @@
 name: Swift
-version: 0.2.2
+version: 0.2.3
 description: Appsody runtime for Swift applications
 license: Apache-2.0
 language: swift


### PR DESCRIPTION
Swift 5.1.2 is now released, and includes important fixes for LLDB debugging which improve the behaviour of `appsody debug`.

Bump the stack version so that the Docker image will be rebuilt, picking up Swift 5.1.2.