### PR TITLE
kitura: update to respin Docker image

### DIFF
--- a/incubator/kitura/stack.yaml
+++ b/incubator/kitura/stack.yaml
@@ -1,5 +1,5 @@
 name: Kitura
-version: 0.2.1
+version: 0.2.2
 description: Runtime for Kitura applications
 license: Apache-2.0
 language: swift


### PR DESCRIPTION
Now that a version of the `swift` Appsody image has been released based on Swift 5.1.2, we need to re-spin the Kitura image too.