### PR TITLE
microprofile - Add timeoutSeconds to readinessProbe in app-deploy.yaml

### DIFF
--- a/incubator/java-microprofile/image/config/app-deploy.yaml
+++ b/incubator/java-microprofile/image/config/app-deploy.yaml
@@ -19,6 +19,7 @@ spec:
       port: APPSODY_PORT
     initialDelaySeconds: 5
     periodSeconds: 2
+    timeoutSeconds: 1
   livenessProbe:
     failureThreshold: 12
     httpGet:

--- a/incubator/java-microprofile/image/project/pom.xml
+++ b/incubator/java-microprofile/image/project/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>dev.appsody</groupId>
     <artifactId>java-microprofile</artifactId>
-    <version>0.2.17</version>
+    <version>0.2.19</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/incubator/java-microprofile/stack.yaml
+++ b/incubator/java-microprofile/stack.yaml
@@ -1,5 +1,5 @@
 name: Eclipse MicroProfile®
-version: 0.2.18
+version: 0.2.19
 description: Eclipse MicroProfile on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
Signed-off-by: Steve Groeger <GROEGES@uk.ibm.com>

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->
Add a timeoutSeconds element to the readinessProbe in the app-deploy.yaml file to resolve an issue with KNative Service creation.

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
Related to https://github.com/appsody/stacks/issues/313