### PR TITLE
spring boot liberty: update stack to set minimum requirements for Docker and CLI

### DIFF
--- a/experimental/java-spring-boot2-liberty/image/Dockerfile-stack
+++ b/experimental/java-spring-boot2-liberty/image/Dockerfile-stack
@@ -51,7 +51,7 @@ ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/target
 ENV APPSODY_WATCH_REGEX="^.*(.xml|.java|.properties)$"
 
-ENV APPSODY_INSTALL="../validate.sh && mvn -B -Dmaven.repo.local=/mvn/repository install -DskipTests"
+ENV APPSODY_PREP="../validate.sh && mvn -B -Dmaven.repo.local=/mvn/repository install -DskipTests"
 
 ENV APPSODY_RUN="mvn -B -Dmaven.repo.local=/mvn/repository liberty:run"
 ENV APPSODY_RUN_ON_CHANGE="mvn -Dmaven.repo.local=/mvn/repository package -DskipTests"

--- a/experimental/java-spring-boot2-liberty/stack.yaml
+++ b/experimental/java-spring-boot2-liberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Spring Boot® on Open Liberty
-version: 0.1.10
+version: 0.1.11
 description: Spring Boot on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java
@@ -8,3 +8,6 @@ maintainers:
    email: ozzy@ca.ibm.com
    github-id: bardweller
 default-template: default
+requirements:
+  docker-version: ">= 17.09.0"
+  appsody-version: ">= 0.2.7"


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

- Update the stack to use`APPSODY_PREP` instead of `APPSODY_INSTALL`
- Because this stack uses `chown`, set Docker requirement to >= 17.09.0 to avoid errors down the development line for users with lower versions of Docker.

### Related Issues:
Related to: https://github.com/appsody/stacks/issues/493