### PR TITLE
nodejs-express: fix appsody init and lint warnings

### DIFF
--- a/incubator/nodejs-express/image/Dockerfile-stack
+++ b/incubator/nodejs-express/image/Dockerfile-stack
@@ -1,5 +1,6 @@
 FROM appsody/nodejs:0.2
 
+ENV APPSODY_PROJECT_DIR=/project
 ENV APPSODY_MOUNTS=/:/project/user-app
 ENV APPSODY_DEPS=/project/user-app/node_modules
 

--- a/incubator/nodejs-express/image/Dockerfile-stack
+++ b/incubator/nodejs-express/image/Dockerfile-stack
@@ -7,7 +7,7 @@ ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/node_modules
 ENV APPSODY_WATCH_REGEX="^.*.js$"
 
-ENV APPSODY_INSTALL="npm install --prefix user-app && npm audit fix --prefix user-app"
+ENV APPSODY_PREP="npm install --prefix user-app && npm audit fix --prefix user-app"
 
 ENV APPSODY_RUN="npm start"
 ENV APPSODY_RUN_ON_CHANGE="npm start"


### PR DESCRIPTION
    nodejs-express: Set APPSODY_PROJECT_DIR (to the default)
    
    Avoid the warning from appsody init:
    
            [Warning] The stack image does not contain APPSODY_PROJECT_DIR.  Using /project


    nodejs-express: Use APPSODY_PREP instead of APPSODY_INSTALL
    
    As recommended:
    
            % appsody stack lint
            LINTING nodejs-express
            Linting Dockerfile-stack:
            /home/sam/w/ibm-cloud/appsody-stacks/incubator/nodejs-express/image/Dockerfile-stack
            [Warning] APPSODY_INSTALL should be deprecated and APPSODY_PREP should be used instead



### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->