### PR TITLE
java-spring-boot2-liberty: use go templating

### DIFF
--- a/experimental/java-spring-boot2-liberty/image/Dockerfile-stack
+++ b/experimental/java-spring-boot2-liberty/image/Dockerfile-stack
@@ -1,13 +1,5 @@
 FROM adoptopenjdk/openjdk8-openj9
 
-# passed in via package script
-ARG GIT_ORG_REPO=appsody/stacks
-ARG IMAGE_REGISTRY_ORG=appsody
-ARG STACK_ID=java-spring-boot2-liberty
-ARG MAJOR_VERSION=0
-ARG MINOR_VERSION=1
-ARG PATCH_VERSION=0
-
 USER root
 RUN  apt-get -qq update \
   && apt-get -qq install -y curl maven wget unzip xmlstarlet \
@@ -20,18 +12,6 @@ COPY ./project /project
 COPY ./config /config
 
 WORKDIR /project
-
-# Update maven artifacts to use stack version information
-# Update Dockerfile to build from this appsody stack image (by range)
-RUN if [ ${MAJOR_VERSION} -eq 0 ]; then \
-      export IMAGE_VERSION=${MAJOR_VERSION}.${MINOR_VERSION}; \
-    else \
-      export IMAGE_VERSION=${MAJOR_VERSION}; \
-    fi \
- && export MAVEN_ARTIFACT_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}" \
- && sed -i -e "s|{{APPSODY_STACK}}|${IMAGE_REGISTRY_ORG}/${STACK_ID}:${IMAGE_VERSION}|" \
-           -e "s|{{APPSODY_STACK_FULL}}|${IMAGE_REGISTRY_ORG}/${STACK_ID}:${MAVEN_ARTIFACT_VERSION}|" /project/Dockerfile \
- && sed -i -e "s|{{MAVEN_ARTIFACT_VERSION}}|${MAVEN_ARTIFACT_VERSION}|" /project/pom.xml
 
 # Build utility for version range processing
 # Install parent pom

--- a/experimental/java-spring-boot2-liberty/image/project/Dockerfile
+++ b/experimental/java-spring-boot2-liberty/image/project/Dockerfile
@@ -1,4 +1,4 @@
-FROM {{APPSODY_STACK}} as compile
+FROM {{.stack.image.namespace}}/{{.stack.id}}:{{.stack.semver.major}}.{{.stack.semver.minor}} as compile
 
 COPY . /project
 
@@ -41,7 +41,7 @@ ENV JVM_ARGS=""
 
 LABEL org.opencontainers.image.version="${version}"
 LABEL org.opencontainers.image.title="${artifactId}"
-LABEL appsody.stack="{{APPSODY_STACK_FULL}}"
+LABEL appsody.stack="{{.stack.image.namespace}}/{{.stack.id}}:{{.stack.semver.major}}.{{.stack.semver.minor}}.{{.stack.semver.patch}}"
 
 EXPOSE 9080
 EXPOSE 9443

--- a/experimental/java-spring-boot2-liberty/image/project/pom.xml
+++ b/experimental/java-spring-boot2-liberty/image/project/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>dev.appsody</groupId>
     <artifactId>java-spring-boot2-liberty</artifactId>
-    <version>{{MAVEN_ARTIFACT_VERSION}}</version>
+    <version>{{.stack.semver.major}}.{{.stack.semver.minor}}.{{.stack.semver.patch}}</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/experimental/java-spring-boot2-liberty/stack.yaml
+++ b/experimental/java-spring-boot2-liberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Spring Boot® on Open Liberty
-version: 0.1.10
+version: 0.1.11
 description: Spring Boot on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Checklist:
- [x] Read the Code of Conduct and Contributing Guidelines.

- [x] Followed the commit message guidelines.

- [x] Stack adheres to Appsody stack structure.

### Modifying an existing stack:
- [x] Updated the stack version in stack.yaml

Changed stack to use Go templating functionality

### Related Issues:
Related to appsody/appsody#528