### PR TITLE
java-spring-boot2: Use exec and mvnw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 **/target
 **/.settings
 **/.project
+**/.classpath
 .*.swp
 __pycache__/
 *.py[cod]

--- a/incubator/java-spring-boot2/image/project/.appsody-init.bat
+++ b/incubator/java-spring-boot2/image/project/.appsody-init.bat
@@ -1,10 +1,14 @@
 if not exist %SystemDrive%%HOMEPATH%\.m2\repository\ (
   mkdir %SystemDrive%%HOMEPATH%\.m2\repository
 )
-setlocal
-set JAVA_FOUND=0
-where java >nul 2>nul
-if %ERRORLEVEL% EQU 0 set JAVA_FOUND=1
-if defined JAVA_HOME set JAVA_FOUND=1
-if "%JAVA_FOUND%"==1 mvnw install -q -f ./appsody-boot2-pom.xml
 
+copy mvnw*.* .. >nul
+mkdir ..\.mvn
+robocopy .mvn ..\.mvn /e /njh /njs /ndl /nc /ns >nul
+
+where java >nul 2>nul
+if %ERRORLEVEL% EQU 0 (
+  if defined JAVA_HOME (
+    ..\mvnw install -q -f ./appsody-boot2-pom.xml
+  )
+)

--- a/incubator/java-spring-boot2/image/project/.appsody-init.sh
+++ b/incubator/java-spring-boot2/image/project/.appsody-init.sh
@@ -22,3 +22,7 @@ which java 2>&1 >/dev/null ; JAVA_KNOWN=$?
 if [ ! -z "$JAVA_HOME" ] || [ $JAVA_KNOWN = "0" ]; then
   ./mvnw install -q -f ./appsody-boot2-pom.xml
 fi
+
+# copy the maven wrapper from the stack to extracted application directory
+cp -Rp mvnw* ..
+cp -Rp .mvn ..

--- a/incubator/java-spring-boot2/image/project/java-spring-boot2-build.sh
+++ b/incubator/java-spring-boot2/image/project/java-spring-boot2-build.sh
@@ -37,6 +37,11 @@ run_mvn () {
   mvn --no-transfer-progress ${MVN_COLOR} "$@"
 }
 
+exec_run_mvn () {
+  echo -e "${GREEN}> mvn $@${NO_COLOR}"
+  exec mvn --no-transfer-progress ${MVN_COLOR} "$@"
+}
+
 common() {
   # Test pom.xml is present and a file.
   if [ ! -f ./pom.xml ]; then
@@ -114,30 +119,30 @@ the parent version in pom.xml, and test your changes.
 
 recompile() {
   note "Compile project in the foreground"
-  run_mvn compile
+  exec_run_mvn compile
 }
 
 package() {
   note "Package project in the foreground"
-  run_mvn clean package verify
+  exec_run_mvn clean package verify
 }
 
 debug() {
   note "Build and debug project in the foreground"
-  run_mvn -Dmaven.test.skip=true \
+  exec_run_mvn -Dmaven.test.skip=true \
     -Dspring-boot.run.jvmArguments='-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005' \
     spring-boot:run
 }
 
 run() {
   note "Build and run project in the foreground"
-  run_mvn -Dmaven.test.skip=true \
+  exec_run_mvn -Dmaven.test.skip=true \
     clean spring-boot:run
 }
 
 test() {
   note "Test project in the foreground"
-  run_mvn package test
+  exec_run_mvn package test
 }
 
 #set the action, default to fail text if none passed.

--- a/incubator/java-spring-boot2/stack.yaml
+++ b/incubator/java-spring-boot2/stack.yaml
@@ -1,5 +1,5 @@
 name: Spring Boot®
-version: 0.3.17
+version: 0.3.18
 description: Spring Boot using OpenJ9 and Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

* The stack will copy mvnw (and supporting files) to the new project at init time, which means that mvnw does not need to be installed by every individual template.
* The launch script will use exec when launching maven, to ensure that all signals go directly to the maven process (as they would when running directly on the command line).

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->