### PR TITLE
java-microprofile: run mvn command in batch to prevent hanging build

### DIFF
--- a/incubator/java-microprofile/image/project/Dockerfile
+++ b/incubator/java-microprofile/image/project/Dockerfile
@@ -17,7 +17,7 @@ COPY ./user-app/pom.xml /project/user-app/pom.xml
 RUN cd /project/user-app && mvn package -Dskip=true -DskipTests
 
 # Download Open Liberty here to prevent redownloading each time the app is changed
-RUN cd /project/user-app && mvn liberty:install-server
+RUN cd /project/user-app && mvn -B liberty:install-server
 
 # Copy and build the application source
 COPY ./user-app/src /project/user-app/src

--- a/incubator/java-microprofile/image/project/pom.xml
+++ b/incubator/java-microprofile/image/project/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>dev.appsody</groupId>
     <artifactId>java-microprofile</artifactId>
-    <version>0.2.20</version>
+    <version>0.2.21</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/incubator/java-microprofile/stack.yaml
+++ b/incubator/java-microprofile/stack.yaml
@@ -1,5 +1,5 @@
 name: Eclipse MicroProfile®
-version: 0.2.20
+version: 0.2.21
 description: Eclipse MicroProfile on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

Previously, `appsody build` would hang when attempting to download the `open-liberty-runtime` zip. By running the mvn command associated with this in batch, the download completes successfully.

cc @scottkurz - Should we be running all mvn commands as batch?

### Related Issues:
Fixes: https://github.com/appsody/stacks/issues/479#issuecomment-558307459