### PR TITLE
nodejs-functions: fix linter and appsody test errors

### DIFF
--- a/experimental/nodejs-functions/image/Dockerfile-stack
+++ b/experimental/nodejs-functions/image/Dockerfile-stack
@@ -6,7 +6,7 @@ ENV APPSODY_DEPS=/project/user-app/functions/node_modules
 ENV APPSODY_WATCH_DIR=/project/user-app/functions
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/functions/node_modules
 
-ENV APPSODY_INSTALL="npm install --prefix user-app/functions && npm audit fix --prefix user-app/functions"
+ENV APPSODY_PREP="npm install --prefix user-app/functions && npm audit fix --prefix user-app/functions"
 
 ENV APPSODY_RUN="npm start"
 ENV APPSODY_RUN_ON_CHANGE="npm start"

--- a/experimental/nodejs-functions/image/Dockerfile-stack
+++ b/experimental/nodejs-functions/image/Dockerfile-stack
@@ -8,6 +8,9 @@ ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/functions/node_modules
 
 ENV APPSODY_INSTALL="npm install --prefix user-app/functions && npm audit fix --prefix user-app/functions"
 
+ENV APPSODY_RUN="npm start"
+ENV APPSODY_RUN_ON_CHANGE="npm start"
+
 ENV APPSODY_TEST="npm test && npm test --prefix user-app/functions"
 
 COPY ./LICENSE /licenses/

--- a/experimental/nodejs-functions/image/Dockerfile-stack
+++ b/experimental/nodejs-functions/image/Dockerfile-stack
@@ -10,8 +10,15 @@ ENV APPSODY_PREP="npm install --prefix user-app/functions && npm audit fix --pre
 
 ENV APPSODY_RUN="npm start"
 ENV APPSODY_RUN_ON_CHANGE="npm start"
+ENV APPSODY_RUN_KILL=true
+
+ENV APPSODY_DEBUG="npm run debug"
+ENV APPSODY_DEBUG_ON_CHANGE="npm run debug"
+ENV APPSODY_DEBUG_KILL=true
 
 ENV APPSODY_TEST="npm test && npm test --prefix user-app/functions"
+ENV APPSODY_TEST_ON_CHANGE=""
+ENV APPSODY_TEST_KILL=false
 
 COPY ./LICENSE /licenses/
 COPY ./project /project/user-app

--- a/experimental/nodejs-functions/image/project/package.json
+++ b/experimental/nodejs-functions/image/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-functions",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Node.js Functions Stack",
   "license": "Apache-2.0",
   "repository": {

--- a/experimental/nodejs-functions/stack.yaml
+++ b/experimental/nodejs-functions/stack.yaml
@@ -8,3 +8,5 @@ maintainers:
     email: cnbailey@gmail.com
     github-id: seabaylea
 default-template: simple
+requirements:
+  appsody-version: ">= 0.2.7"

--- a/experimental/nodejs-functions/stack.yaml
+++ b/experimental/nodejs-functions/stack.yaml
@@ -1,5 +1,5 @@
 name: Node.js Functions
-version: 0.1.5
+version: 0.1.6
 description: Serverless runtime for Node.js functions
 license: Apache-2.0
 language: nodejs


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

- Fixes the Linter problems for nodejs-functions by adding inherited commands from nodejs-express into the stack
- Replaces `APPSODY_INSTALL` with `APPSODY_PREP` which was previously causing issues with inheritance from `nodejs-express`
- Adds a test file and directory to the template

### Related Issues:
Fixes: https://github.com/appsody/stacks/issues/534