### PR TITLE
Add support for the --image-registry argument on appsody stack cmds

### DIFF
--- a/ci/download_cli.sh
+++ b/ci/download_cli.sh
@@ -13,7 +13,7 @@ then
     fi
     if [ -z "${APPSODY_CLI_FALLBACK}" ]
     then
-        APPSODY_CLI_FALLBACK=0.5.2
+        APPSODY_CLI_FALLBACK=0.5.3
     fi
 
     script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )

--- a/ci/env.sh
+++ b/ci/env.sh
@@ -125,6 +125,12 @@ then
     export IMAGE_REGISTRY_ORG=appsody
 fi
 
+# image registry for publishing stack
+if [ -z "$IMAGE_REGISTRY" ]
+then
+    export IMAGE_REGISTRY=docker.io
+fi
+
 if [ -z $GIT_BRANCH ]
 then
     export GIT_BRANCH=$(git for-each-ref --format='%(refname:lstrip=2)' "$(git symbolic-ref -q HEAD)")
@@ -228,14 +234,7 @@ image_push() {
     if [ "$IMAGE_REGISTRY_PUBLISH" == "true" ]
     then
         local name=$@
-        if [ -n "$IMAGE_REGISTRY" ]	
-        then	
-            echo "Tagging ${IMAGE_REGISTRY}/$name"	
-            image_tag $name ${IMAGE_REGISTRY}/$name	
 
-            name=${IMAGE_REGISTRY}/$name	
-        fi
-       
         echo "Pushing $name"
         if [ "$USE_BUILDAH" == "true" ]; then
             buildah push --tls-verify=false $name

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -66,10 +66,10 @@ do
                     retcode=0
                     
                     if [ "$CI_WAIT_FOR" != "" ]; then
-                        $appsody_cmd -v --image-namespace $IMAGE_REGISTRY_ORG  2>&1 || retcode=$?
+                        $appsody_cmd -v --image-registry $IMAGE_REGISTRY --image-namespace $IMAGE_REGISTRY_ORG  2>&1 || retcode=$?
                     else
                         echo "File containing output from image build: $logFileName"
-                        $appsody_cmd -v --image-namespace $IMAGE_REGISTRY_ORG  > $logFileName 2>&1 || retcode=$?
+                        $appsody_cmd -v --image-registry $IMAGE_REGISTRY --image-namespace $IMAGE_REGISTRY_ORG  > $logFileName 2>&1 || retcode=$?
                     fi
                    
                     if [ $retcode != 0 ]; then
@@ -86,10 +86,10 @@ do
                         echo "created $IMAGE_REGISTRY_ORG/$stack_id:$stack_version"
                     fi
 
-                    echo "$IMAGE_REGISTRY_ORG/$stack_id" >> $build_dir/image_list
-                    echo "$IMAGE_REGISTRY_ORG/$stack_id:$stack_version" >> $build_dir/image_list
-                    echo "$IMAGE_REGISTRY_ORG/$stack_id:$stack_version_major" >> $build_dir/image_list
-                    echo "$IMAGE_REGISTRY_ORG/$stack_id:$stack_version_major.$stack_version_minor" >> $build_dir/image_list
+                    echo "$IMAGE_REGISTRY/$IMAGE_REGISTRY_ORG/$stack_id" >> $build_dir/image_list
+                    echo "$IMAGE_REGISTRY/$IMAGE_REGISTRY_ORG/$stack_id:$stack_version" >> $build_dir/image_list
+                    echo "$IMAGE_REGISTRY/$IMAGE_REGISTRY_ORG/$stack_id:$stack_version_major" >> $build_dir/image_list
+                    echo "$IMAGE_REGISTRY/$IMAGE_REGISTRY_ORG/$stack_id:$stack_version_major.$stack_version_minor" >> $build_dir/image_list
 
                     echo "File containing output from add-to-repo: ${build_dir}/add-to-repo.$stack_id.$stack_version.log"
                     if ${CI_WAIT_FOR} appsody stack add-to-repo $repo_name -v --release-url $RELEASE_URL/$stack_id-v$stack_version/$repo_name. $useCachedIndex \
@@ -164,18 +164,18 @@ fi
 
 echo "File containing output from $INDEX_IMAGE build: ${build_dir}/image.$INDEX_IMAGE.${INDEX_VERSION}.log"
 if ${CI_WAIT_FOR} image_build $nginx_arg \
-    -t $IMAGE_REGISTRY_ORG/$INDEX_IMAGE \
-    -t $IMAGE_REGISTRY_ORG/$INDEX_IMAGE:${INDEX_VERSION} \
+    -t $IMAGE_REGISTRY/$IMAGE_REGISTRY_ORG/$INDEX_IMAGE \
+    -t $IMAGE_REGISTRY/$IMAGE_REGISTRY_ORG/$INDEX_IMAGE:${INDEX_VERSION} \
     -f $script_dir/nginx/Dockerfile $script_dir \
     > ${build_dir}/image.$INDEX_IMAGE.${INDEX_VERSION}.log
 then
     trace  "Output from $INDEX_IMAGE build" "${build_dir}/image.$INDEX_IMAGE.${INDEX_VERSION}.log"
 
     echo "created $IMAGE_REGISTRY_ORG/$INDEX_IMAGE:${INDEX_VERSION}"
-    echo "$IMAGE_REGISTRY_ORG/$INDEX_IMAGE" >> $build_dir/image_list
-    echo "$IMAGE_REGISTRY_ORG/$INDEX_IMAGE:${INDEX_VERSION}" >> $build_dir/image_list
+    echo "$IMAGE_REGISTRY/$IMAGE_REGISTRY_ORG/$INDEX_IMAGE" >> $build_dir/image_list
+    echo "$IMAGE_REGISTRY/$IMAGE_REGISTRY_ORG/$INDEX_IMAGE:${INDEX_VERSION}" >> $build_dir/image_list
 else
-    echo "failed building $IMAGE_REGISTRY_ORG/$INDEX_IMAGE:${INDEX_VERSION}"
+    echo "failed building $IMAGE_REGISTRY/$IMAGE_REGISTRY_ORG/$INDEX_IMAGE:${INDEX_VERSION}"
     cat "${build_dir}/image.$INDEX_IMAGE.${INDEX_VERSION}.log"
     exit 1
 fi


### PR DESCRIPTION
Signed-off-by: Steve Groeger <GROEGES@uk.ibm.com>

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->
Added support for the --image-registry argument on the appsody stack package and validate commands

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
Fixes https://github.com/appsody/stacks/issues/563