### PR TITLE
extend timeout; simplify log files

### DIFF
--- a/ci/env.sh
+++ b/ci/env.sh
@@ -97,7 +97,27 @@ stderr() {
 }
 
 trace() {
-    if [ "${VERBOSE}" == "true" ]
+    for x in "$@"
+    do
+        if [ -f "$x" ]
+        then
+            if [ "${VERBOSE}" == "true" ]
+            then
+                >&2 cat "$x"
+            else
+                >&2 echo -e "\n--- Last 20 lines ---"
+                >&2 tail -n 20 "$x"
+                >&2 echo "--- ---"
+            fi
+        elif [ -z "${CI_WAIT_FOR}" ]
+        then
+            >&2 echo "$x"
+        fi
+    done
+}
+
+error_cat() {
+    if [ -z "${CI_WAIT_FOR}" ]
     then
         for x in "$@"
         do
@@ -193,12 +213,7 @@ fi
 
 if [ -z "$IMAGE_REGISTRY_PUBLISH" ]
 then
-    if [ -z "$TRAVIS_TAG" ]
-    then
-        export IMAGE_REGISTRY_PUBLISH=false
-    else
-        export IMAGE_REGISTRY_PUBLISH=true
-    fi
+    export IMAGE_REGISTRY_PUBLISH=false
 fi
 
 if [ -z "$DISPLAY_NAME_PREFIX" ]

--- a/ci/ext/pre_env.d/10_travis
+++ b/ci/ext/pre_env.d/10_travis
@@ -8,7 +8,7 @@ then
     export GIT_ORG_REPO=${TRAVIS_REPO_SLUG}
     export INDEX_VERSION=${TRAVIS_BUILD_NUMBER}
 
-    export CI_WAIT_FOR='travis_wait'
+    export CI_WAIT_FOR='travis_wait 30'
 
     if [ $TRAVIS_TAG ] && [ "$TRAVIS_TAG" == "$TRAVIS_BRANCH" ]
     then

--- a/incubator/java-spring-boot2/image/project/java-spring-boot2-build.sh
+++ b/incubator/java-spring-boot2/image/project/java-spring-boot2-build.sh
@@ -78,7 +78,12 @@ common() {
   then
     # Install parent pom
     note "Installing parent ${a_groupId}:${a_artifactId}:${a_version}"
-    run_mvn install -q -f /project/appsody-boot2-pom.xml
+    if [ -z "${APPSODY_DEV_MODE}" ]
+    then
+      run_mvn install -q -f /project/appsody-boot2-pom.xml
+    else
+      run_mvn install -f /project/appsody-boot2-pom.xml
+    fi
   fi
 
   local p_groupId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:parent/x:groupId" pom.xml)


### PR DESCRIPTION
### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

Break appsody stack commands into three:  lint, package, validate (no-lint, no-package)
Extend travis timeout, use CI_WAIT_FOR (travis_wait) consistently
Use in-built travis log
Remove verbose flag (this will be better once appsody CLI brings in fix for verbose flags in stack package)
Remove a dangling Travis reference