### PR TITLE
Altered default travis stacks list to improve build time

### DIFF
--- a/ci/ext/pre_list.d/10_travis
+++ b/ci/ext/pre_list.d/10_travis
@@ -104,6 +104,6 @@ then
     if [ -z "${STACKS_LIST}" ]
     then
         echo "Choosing a subset of stacks to test with CI/CD changes"
-        export STACKS_LIST="incubator/java-microprofile incubator/java-spring-boot2 incubator/nodejs experimental/java-spring-boot2-liberty"
+        export STACKS_LIST="incubator/java-openliberty incubator/java-spring-boot2 incubator/nodejs-express"
     fi
 fi


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).

- Currently the travis build time for non stack specific changes builds 4 different stacks as default. This can cause the travis build to take upwards of 45 minutes. This PR alters the list in hopes to improve this.

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->