### PR TITLE
Invoke configure.sh to populate SCC

### DIFF
--- a/incubator/java-openliberty/image/project/Dockerfile
+++ b/incubator/java-openliberty/image/project/Dockerfile
@@ -31,5 +31,4 @@ FROM open-liberty:kernel-java8-openj9
 COPY --chown=1001:0 --from=0 /config/ /config/
 COPY --chown=1001:0 --from=0 /project/user-app/target/*.war /config/apps
 
-EXPOSE 9080
-EXPOSE 9443
+RUN configure.sh

--- a/incubator/java-openliberty/image/project/pom.xml
+++ b/incubator/java-openliberty/image/project/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>dev.appsody</groupId>
     <artifactId>java-openliberty</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/incubator/java-openliberty/stack.yaml
+++ b/incubator/java-openliberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Open Liberty
-version: 0.1.0
+version: 0.1.1
 description: Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
Signed-off-by: Arthur De Magalhaes <ademagalhaes@gmail.com>

### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [X] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [X] Updated the stack version in `stack.yaml`

- Invoke `configure.sh`, which will populate the shared class cache (see [this PR](https://github.com/OpenLiberty/ci.docker/pull/117))
- Remove the 2 instructions for the port, since that's already done in the [base image](https://github.com/OpenLiberty/ci.docker/blob/master/releases/latest/kernel/Dockerfile.ubuntu.adoptopenjdk8#L81)

