### PR TITLE
Fix appsody init on Windows for quarkus stack.

### DIFF
--- a/experimental/quarkus/image/project/.appsody-init.bat
+++ b/experimental/quarkus/image/project/.appsody-init.bat
@@ -3,4 +3,4 @@ set JAVA_FOUND=0
 where java >nul 2>nul
 if %ERRORLEVEL% EQU 0 set JAVA_FOUND=1
 if defined JAVA_HOME set JAVA_FOUND=1
-if "%JAVA_FOUND%"==1 mvnw install -Denforcer.skip=true
+if "%JAVA_FOUND%"=="1" mvnw install -Denforcer.skip=true

--- a/experimental/quarkus/stack.yaml
+++ b/experimental/quarkus/stack.yaml
@@ -1,5 +1,5 @@
 name: Quarkus
-version: 0.2.2
+version: 0.2.3
 description: Quarkus runtime for running Java applications
 license: Apache-2.0
 language: java


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

### Checklist:

- [X ] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [X ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [X ] Updated the stack version in `stack.yaml`


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
Partial fix to #538 (fixes for this stack).
