### PR TITLE
Java-openliberty: cache maven dependancies with an attempt to cache the MicroProfile feature.  

### DIFF
--- a/incubator/java-openliberty/image/project/Dockerfile
+++ b/incubator/java-openliberty/image/project/Dockerfile
@@ -12,23 +12,29 @@ RUN cd /project && mvn -B install dependency:go-offline -DskipTests
 COPY ./util /project/util
 RUN  /project/util/check_version build
 
-# Copy the user's application pom and resolve all dependencies, also trigger Open Liberty install
+# Copy the user's application pom and resolve all dependencies
 COPY ./user-app/pom.xml /project/user-app/pom.xml
+RUN cd /project/user-app && mvn package -Dskip=true -DskipTests
+
+# Download Openliberty here to prevent a re-download 
+RUN cd /project/user-app && mvn -B liberty:install-server liberty:create
+
+# validate the config.
 COPY ./validate.sh /project/user-app/validate.sh
 RUN cd /project/user-app && ./validate.sh
 
 # Copy and build the application source, and run unit tests
 COPY ./user-app/src /project/user-app/src
-RUN cd /project/user-app && mvn -B liberty:create package
+RUN cd /project/user-app && mvn package -DskipTests
 
-RUN cd /project/user-app/target/liberty/wlp/usr/servers && \
-    mkdir /config && \
-    mv defaultServer/* /config/
+RUN cd /project/user-app/target && \
+     mkdir /config && \
+     mv liberty/wlp/usr/servers/*/* /config/
+
 
 # Step 2: Package Open Liberty image
 FROM open-liberty:kernel-java8-openj9
 
 COPY --chown=1001:0 --from=0 /config/ /config/
-COPY --chown=1001:0 --from=0 /project/user-app/target/*.war /config/apps
 
 RUN configure.sh

--- a/incubator/java-openliberty/image/project/pom.xml
+++ b/incubator/java-openliberty/image/project/pom.xml
@@ -38,7 +38,26 @@
             <url>/mvn/repository</url>
         </repository>
     </repositories>
-
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.openliberty.features</groupId>
+                <artifactId>features-bom</artifactId>
+                <version>${version.openliberty-runtime}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+         <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>3.2</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
     <build>
         <pluginManagement>
             <plugins>

--- a/incubator/java-openliberty/stack.yaml
+++ b/incubator/java-openliberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Open Liberty
-version: 0.1.2
+version: 0.1.3
 description: Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java

--- a/incubator/java-openliberty/templates/default/pom.xml
+++ b/incubator/java-openliberty/templates/default/pom.xml
@@ -18,14 +18,6 @@
     <packaging>war</packaging>
 
     <dependencies>
-        <!-- Aggregate of MicroProfile APIs -->
-        <dependency>
-            <groupId>org.eclipse.microprofile</groupId>
-            <artifactId>microprofile</artifactId>
-            <version>3.2</version>
-            <type>pom</type>
-            <scope>provided</scope>
-        </dependency>
         <!-- For tests -->
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
