### PR TITLE
java-openliberty: update validate script

### DIFF
--- a/incubator/java-openliberty/image/project/validate.sh
+++ b/incubator/java-openliberty/image/project/validate.sh
@@ -22,16 +22,6 @@ if [ ! -z "$APPSODY_DEV_MODE" ]; then
     M2_LOCAL_REPO="-Dmaven.repo.local=/mvn/repository"
 fi
 
-
-# Get parent pom information (../pom.xml)
-args='export PARENT_GROUP_ID=${project.groupId}; export PARENT_ARTIFACT_ID=${project.artifactId}; export PARENT_VERSION=${project.version}
-export LIBERTY_GROUP_ID=${liberty.groupId}; export LIBERTY_ARTIFACT_ID=${liberty.artifactId}; export LIBERTY_VERSION=${version.openliberty-runtime}'
-eval $(mvn -q -Dexec.executable=echo $M2_LOCAL_REPO -Dexec.args="${args}" --non-recursive -f ../pom.xml exec:exec 2>/dev/null)
-
-# Install parent pom
-echo "Installing parent ${PARENT_GROUP_ID}:${PARENT_ARTIFACT_ID}:${PARENT_VERSION}"
-mvn install  $M2_LOCAL_REPO -Denforcer.skip=true -f ../pom.xml
-
 # Get parent pom information
 a_groupId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:groupId" /project/pom.xml)
 a_artifactId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:artifactId" /project/pom.xml)
@@ -40,6 +30,12 @@ p_groupId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x
 p_artifactId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:parent/x:artifactId" pom.xml)
 p_version_range=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:parent/x:version" pom.xml)
 
+# Install parent pom
+echo "Installing parent ${a_groupId}:${a_artifactId}:${a_version}"
+mvn install $M2_LOCAL_REPO -Denforcer.skip=true -f ../pom.xml
+
+
+
 # Check child pom for required parent project
 if [ "${p_groupId}" != "${a_groupId}" ] || [ "${p_artifactId}" != "${a_artifactId}" ]; then
   echo "Project pom.xml is missing the required parent:
@@ -47,8 +43,7 @@ if [ "${p_groupId}" != "${a_groupId}" ] || [ "${p_artifactId}" != "${a_artifactI
   <parent>
     <groupId>${a_groupId}</groupId>
     <artifactId>${a_artifactId}</artifactId>
-    <version>${a_range}</version>
-    <relativePath/>
+    ...
   </parent>
   "
   exit 1
@@ -60,44 +55,27 @@ if ! /project/util/check_version contains "$p_version_range" "$a_version";  then
 
 The version of the appsody stack '${a_version}' does not match the
 parent version specified in pom.xml '${p_version_range}'. Please update
-the parent version in pom.xml, and test your changes.
-
-  <parent>
-    <groupId>${a_groupId}</groupId>
-    <artifactId>${a_artifactId}</artifactId>
-    <version>${a_range}</version>
-    <relativePath/>
-  </parent>
-  "
+the parent version in pom.xml, and test your changes."
   exit 1
 fi
 
-# Skip check below, not sure if we should fix or just remove.   It doesn't account for the fact that
-# the stack now uses pluginManagement, so we could fix to allow this as an acceptable usage too... but what if Jane introduces a profile?
-exit 0
 
-# Check child pom for required liberty version, groupID and artifactId
-l_groupId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:build/x:plugins/x:plugin[x:artifactId='liberty-maven-plugin']/x:configuration/x:assemblyArtifact/x:groupId" pom.xml)
-l_artifactId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:build/x:plugins/x:plugin[x:artifactId='liberty-maven-plugin']/x:configuration/x:assemblyArtifact/x:artifactId" pom.xml)
-l_version=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:build/x:plugins/x:plugin[x:artifactId='liberty-maven-plugin']/x:configuration/x:assemblyArtifact/x:version" pom.xml)
+# Check that the child pom has not overridden the Open Liberty version
+child_ol_version_property=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:properties/x:version.openliberty-runtime" pom.xml)
+child_ol_groupId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:build/x:plugins/x:plugin[x:artifactId='liberty-maven-plugin']/x:configuration/x:runtimeArtifact/x:groupId" pom.xml)
+child_ol_artifactId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:build/x:plugins/x:plugin[x:artifactId='liberty-maven-plugin']/x:configuration/x:runtimeArtifact/x:artifactId" pom.xml)
+child_ol_version=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:build/x:plugins/x:plugin[x:artifactId='liberty-maven-plugin']/x:configuration/x:runtimeArtifact/x:version" pom.xml)
+
 if ! [[
-        ( "${l_groupId}" == "${LIBERTY_GROUP_ID}" && "${l_artifactId}" == "${LIBERTY_ARTIFACT_ID}" && "${l_version}" == "${LIBERTY_VERSION}"  )
-        ||
-        ( "${l_groupId}" == "\${liberty.groupId}" && "${l_artifactId}" == "\${liberty.artifactId}" && "${l_version}" == "\${version.openliberty-runtime}" )
+        ( "${child_ol_groupId}" == "")
+        &&
+        ( "${child_ol_artifactId}" == "")
+        &&
+        ( "${child_ol_version}" == "")
+        &&
+        ("${child_ol_version_property}" == "")
      ]]
 then
-  echo "Project is not using the right OpenLiberty assembly artifact:
-  <assemblyArtifact>
-    <groupId>${LIBERTY_GROUP_ID}</groupId>
-    <artifactId>${LIBERTY_ARTIFACT_ID}</artifactId>
-    <version>${LIBERTY_VERSION}</version>
-  </assemblyArtifact>
-
-Alternatively you could also use these properties:
-  <assemblyArtifact>
-    <groupId>\${liberty.groupId}</groupId>
-    <artifactId>\${liberty.artifactId}</artifactId>
-    <version>\${version.openliberty-runtime}</version>
-  <assemblyArtifact>"
+  echo "The project is not using the Open Liberty runtime definition of the parent."
   exit 1
 fi

--- a/incubator/java-openliberty/stack.yaml
+++ b/incubator/java-openliberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Open Liberty
-version: 0.1.7
+version: 0.1.8
 description: Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Checklist:

- [x ] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [ x] Updated the stack version in `stack.yaml`

Currently we are getting parent pom properties in the validate script (groupid, artifactid, version) via a call to the maven exec plugin. This takes time and can be replaced by building a DOM on the pom (which we are already doing further down in the script. 

This change cuts off about 5 seconds for `appsody run`. 