### PR TITLE
Java-openliberty: Cache resources from initial server startup in stack image

### DIFF
--- a/incubator/java-openliberty/image/Dockerfile-stack
+++ b/incubator/java-openliberty/image/Dockerfile-stack
@@ -15,7 +15,8 @@ RUN  /project/util/check_version build
 WORKDIR /project/
 RUN mkdir -p /mvn/repository
 RUN mvn -B -Dmaven.repo.local=/mvn/repository -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
-RUN mvn -B -Pstack-image-package -Dmaven.repo.local=/mvn/repository liberty:install-server liberty:create install dependency:go-offline
+RUN mvn -B -Pstack-image-package -Dmaven.repo.local=/mvn/repository liberty:install-server install 
+RUN mvn -B -Pstack-image-run -Dmaven.repo.local=/mvn/repository -DserverXmlFile=init-server.xml liberty:create liberty:start liberty:stop
 RUN chmod -R 777 /opt/ol
 
 

--- a/incubator/java-openliberty/image/Dockerfile-stack
+++ b/incubator/java-openliberty/image/Dockerfile-stack
@@ -15,8 +15,8 @@ RUN  /project/util/check_version build
 WORKDIR /project/
 RUN mkdir -p /mvn/repository
 RUN mvn -B -Dmaven.repo.local=/mvn/repository -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
-RUN mvn -B -Pstack-image-package -Dmaven.repo.local=/mvn/repository liberty:install-server install 
-RUN mvn -B -Pstack-image-run -Dmaven.repo.local=/mvn/repository -DserverXmlFile=init-server.xml liberty:create liberty:start liberty:stop
+RUN mvn -B -Pimage-install -Dmaven.repo.local=/mvn/repository liberty:install-server install 
+RUN mvn -B -Pimage-run -Dmaven.repo.local=/mvn/repository -DserverXmlFile=init-server.xml liberty:create liberty:start liberty:stop
 RUN chmod -R 777 /opt/ol
 
 
@@ -35,17 +35,17 @@ ENV APPSODY_USER_RUN_AS_LOCAL=true
 # Set APPSODY_DEV_MODE to get in the habit in case we need it someday
 ENV APPSODY_PREP="export APPSODY_DEV_MODE=prep;  ../validate.sh"
 
-ENV APPSODY_RUN="export APPSODY_DEV_MODE=run; mvn -B -Pstack-image-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository liberty:dev"
+ENV APPSODY_RUN="export APPSODY_DEV_MODE=run; mvn -B -Pimage-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository liberty:dev"
 # See ENV APPSODY_WATCH_REGEX comment
-ENV APPSODY_RUN_ON_CHANGE="export APPSODY_DEV_MODE=run; ../validate.sh && mvn -Pstack-image-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository liberty:dev"
+ENV APPSODY_RUN_ON_CHANGE="export APPSODY_DEV_MODE=run; ../validate.sh && mvn -Pimage-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository liberty:dev"
 ENV APPSODY_RUN_KILL=true
 
-ENV APPSODY_DEBUG="export APPSODY_DEV_MODE=debug; mvn -B -Pstack-image-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository liberty:dev"
+ENV APPSODY_DEBUG="export APPSODY_DEV_MODE=debug; mvn -B -Pimage-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository liberty:dev"
 # See ENV APPSODY_WATCH_REGEX comment
-ENV APPSODY_DEBUG_ON_CHANGE="export APPSODY_DEV_MODE=debug; ../validate.sh && mvn -Pstack-image-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository liberty:dev"
+ENV APPSODY_DEBUG_ON_CHANGE="export APPSODY_DEV_MODE=debug; ../validate.sh && mvn -Pimage-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository liberty:dev"
 ENV APPSODY_DEBUG_KILL=true
 
-ENV APPSODY_TEST="export APPSODY_DEV_MODE=test; exec mvn -B -Pstack-image-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository clean package liberty:create liberty:install-feature liberty:start liberty:deploy failsafe:integration-test@it-exec liberty:stop failsafe:verify"
+ENV APPSODY_TEST="export APPSODY_DEV_MODE=test; exec mvn -B -Pimage-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository clean package liberty:create liberty:install-feature liberty:start liberty:deploy failsafe:integration-test@it-exec liberty:stop failsafe:verify"
 ENV APPSODY_TEST_ON_CHANGE=""
 ENV APPSODY_TEST_KILL=true
 

--- a/incubator/java-openliberty/image/project/init-server.xml
+++ b/incubator/java-openliberty/image/project/init-server.xml
@@ -1,0 +1,11 @@
+<server description="Liberty server">
+    <featureManager>
+        <feature>microProfile-3.2</feature>
+    </featureManager>
+    <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+    <keyStore id="defaultKeyStore" location="key.jks" type="jks" password="mpKeystore"/>
+    <httpEndpoint host="*" httpPort="${default.http.port}" 
+        httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+    
+    <webApplication location="starter-app.war" contextRoot="/"/>
+</server>

--- a/incubator/java-openliberty/image/project/init-server.xml
+++ b/incubator/java-openliberty/image/project/init-server.xml
@@ -4,8 +4,7 @@
     </featureManager>
     <quickStartSecurity userName="admin" userPassword="adminpwd"/>
     <keyStore id="defaultKeyStore" location="key.jks" type="jks" password="mpKeystore"/>
-    <httpEndpoint host="*" httpPort="${default.http.port}" 
-        httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+    <httpEndpoint host="*" httpPort="9080" 
+        httpsPort="9443" id="defaultHttpEndpoint"/>
     
-    <webApplication location="starter-app.war" contextRoot="/"/>
 </server>

--- a/incubator/java-openliberty/image/project/pom.xml
+++ b/incubator/java-openliberty/image/project/pom.xml
@@ -97,7 +97,7 @@
     		property is configured in the Liberty Maven plugin to specify 
     		where to install the Open Liberty runtime in the Docker image. --> 
         <profile>
-            <id>stack-image-package</id>
+            <id>image-install</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
@@ -121,7 +121,7 @@
         	The installDirectory property is configured in the Liberty Maven plugin to specify 
     		where the existing Open Liberty installation is in the Docker image. --> 
         <profile>
-            <id>stack-image-run</id>
+            <id>image-run</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>

--- a/incubator/java-openliberty/stack.yaml
+++ b/incubator/java-openliberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Open Liberty
-version: 0.1.2
+version: 0.1.4
 description: Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Checklist:

- [x ] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x ] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [ x] Updated the stack version in `stack.yaml`

Start and stop the server as part of the stack package process. This "warms" the server, creating LTPA tokens and ssl keys. The temporary configuration used for this server at package time is a copy of the default template server.xml