### PR TITLE
node-red: Run stack as non root

### DIFF
--- a/incubator/node-red/image/Dockerfile-stack
+++ b/incubator/node-red/image/Dockerfile-stack
@@ -7,7 +7,7 @@ ENV APPSODY_DEPS=/project/user-app/node_modules
 ENV APPSODY_USER_RUN_AS_LOCAL=true
 
 ENV APPSODY_WATCH_DIR=/project/user-app
-ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/node_modules
+ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/node_modules;/project/user-app/.config
 ENV APPSODY_WATCH_REGEX="^.*.json$"
 
 ENV APPSODY_PREP="npm install --prefix user-app && npm audit fix --prefix user-app"

--- a/incubator/node-red/image/Dockerfile-stack
+++ b/incubator/node-red/image/Dockerfile-stack
@@ -1,4 +1,6 @@
 FROM node:12
+  
+RUN useradd -m node_user && groupadd node_group
 
 ENV APPSODY_MOUNTS=/:/project/user-app
 ENV APPSODY_DEPS=/project/user-app/node_modules
@@ -7,7 +9,7 @@ ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/node_modules
 ENV APPSODY_WATCH_REGEX="^.*.json$"
 
-ENV APPSODY_INSTALL="npm install --prefix user-app && npm audit fix --prefix user-app"
+ENV APPSODY_PREP="npm install --prefix user-app && npm audit fix --prefix user-app"
 
 ENV APPSODY_RUN="npm start"
 ENV APPSODY_RUN_ON_CHANGE="npm start"
@@ -19,10 +21,14 @@ ENV APPSODY_DEBUG_KILL=true
 
 ENV APPSODY_TEST="npm test"
 
-COPY ./LICENSE /licenses/
-COPY ./project /project
-COPY ./config /config
+COPY --chown=node_user:node_group ./LICENSE /licenses/
+COPY --chown=node_user:node_group ./project /project
+COPY --chown=node_user:node_group ./config /config
+
 WORKDIR /project
+USER node_user
+
+RUN mkdir -p /project/user-app/node_modules
 RUN npm install && npm audit fix
 
 ENV PORT=3000

--- a/incubator/node-red/image/Dockerfile-stack
+++ b/incubator/node-red/image/Dockerfile-stack
@@ -4,6 +4,7 @@ RUN useradd -m node_user && groupadd node_group
 
 ENV APPSODY_MOUNTS=/:/project/user-app
 ENV APPSODY_DEPS=/project/user-app/node_modules
+ENV APPSODY_USER_RUN_AS_LOCAL=true
 
 ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/node_modules
@@ -33,6 +34,7 @@ RUN npm install && npm audit fix
 
 ENV PORT=3000
 ENV NODE_PATH=/project/user-app/node_modules
+ENV NPM_CONFIG_CACHE=/project/user-app/.npm
 
 EXPOSE 3000
 EXPOSE 9229

--- a/incubator/node-red/image/Dockerfile-stack
+++ b/incubator/node-red/image/Dockerfile-stack
@@ -35,6 +35,7 @@ RUN npm install && npm audit fix
 ENV PORT=3000
 ENV NODE_PATH=/project/user-app/node_modules
 ENV NPM_CONFIG_CACHE=/project/user-app/.npm
+ENV XDG_CONFIG_HOME=/project/user-app/.config
 
 EXPOSE 3000
 EXPOSE 9229

--- a/incubator/node-red/image/project/Dockerfile
+++ b/incubator/node-red/image/project/Dockerfile
@@ -1,6 +1,8 @@
 # Install the app dependencies in a full Node docker image
 FROM node:12
 
+RUN useradd -m node_user && groupadd node_group
+
 # Install OS updates
 RUN apt-get update \
  && apt-get dist-upgrade -y \
@@ -21,6 +23,8 @@ WORKDIR /project/user-app/node_modules
 # Copy the dependencies into a slim Node docker image
 FROM node:12-slim
 
+RUN useradd -m node_user && groupadd node_group
+
 # Install OS updates
 RUN apt-get update \
  && apt-get dist-upgrade -y \
@@ -28,18 +32,21 @@ RUN apt-get update \
  && echo 'Finished installing dependencies'
 
 # Copy the project
-COPY --chown=node:node . /project
+COPY --chown=node_user:node_group . /project
 
 # Copy all dependencies
-COPY --chown=node:node --from=0 /project/node_modules /project/node_modules
-COPY --chown=node:node --from=0 /project/user-app/node_modules /project/user-app/node_modules
+COPY --chown=node_user:node_group --from=0 /project/node_modules /project/node_modules
+COPY --chown=node_user:node_group --from=0 /project/user-app/node_modules /project/user-app/node_modules
+
+RUN chown -hR node_user:0 /project \
+ && chmod -R g=u /project
 
 WORKDIR /project
 
 ENV NODE_ENV production
 ENV PORT 3000
 
-USER node
+USER node_user
 
 EXPOSE 3000
 CMD ["npm", "start"]

--- a/incubator/node-red/image/project/package.json
+++ b/incubator/node-red/image/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-stack",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Node-RED Stack",
   "license": "Apache-2.0",
   "repository": {

--- a/incubator/node-red/stack.yaml
+++ b/incubator/node-red/stack.yaml
@@ -1,5 +1,5 @@
 name: Node-RED
-version: 0.1.0
+version: 0.1.1
 description: Node-RED runtime for running flows
 license: Apache-2.0
 language: nodejs
@@ -8,3 +8,6 @@ maintainers:
     email: nick.oleary@gmail.com
     github-id: knolleary
 default-template: simple
+requirements:
+  docker-version: ">= 17.09.0"
+  appsody-version: ">= 0.2.7"

--- a/incubator/node-red/templates/simple/package-lock.json
+++ b/incubator/node-red/templates/simple/package-lock.json
@@ -1,0 +1,5 @@
+{
+    "name": "SampleAppsody-Node-RED-Project",
+    "version": "0.1.0",
+    "lockfileVersion": 1
+}

--- a/incubator/node-red/templates/simple/package.json
+++ b/incubator/node-red/templates/simple/package.json
@@ -1,7 +1,7 @@
 {
     "name": "SampleAppsody-Node-RED-Project",
     "description": "A sample Node-RED Project created with Appsody",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "dependencies": {},
     "node-red": {
         "settings": {


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

Changes to the stack to run as non root user during local development and production. This should avoid any permission problems and solves an issue with appsody build in Openshift. I was having issues setting permissions to the `node` user that comes with the node image and so I created a new user.

### Related Issues:
Related to: https://github.com/appsody/stacks/issues/622
