### PR TITLE
java-openliberty:  Cache maven dependencies for `appsody build`

### DIFF
--- a/incubator/java-openliberty/image/project/Dockerfile
+++ b/incubator/java-openliberty/image/project/Dockerfile
@@ -8,30 +8,30 @@ RUN apt-get update && \
 COPY ./pom.xml /project/pom.xml
 RUN cd /project && mvn -B install dependency:go-offline -DskipTests
 
+# Prime image
+#   a) Prime .m2/repository with common artifacts 
+#   b) Create target/liberty/wlp/usr/servers/defaultServer dir
+COPY ./preload-m2-pom.xml /project/user-app/preload-m2-pom.xml
+RUN cd /project/user-app && \ 
+    mvn -B -f /project/user-app/preload-m2-pom.xml liberty:install-server dependency:go-offline && \
+    rm /project/user-app/preload-m2-pom.xml
+
 # Copy and run a simple version check
 COPY ./util /project/util
 RUN  /project/util/check_version build
 
-#-----
-# Before copying any app file:
-#   - Prime .m2/repository with common artifacts 
-#   - Create target/liberty/wlp/usr/servers/defaultServer dir
-#-----
-COPY ./preload-m2-pom.xml /project/user-app/preload-m2-pom.xml
-RUN cd /project/user-app && \ 
-    mvn -B -f /project/user-app/preload-m2-pom.xml liberty:install-server dependency:resolve-plugins && \
-    rm /project/user-app/preload-m2-pom.xml
-
+# Copy the validate.sh script and application pom.xml
 COPY ./validate.sh /project/user-app/validate.sh
-
-# Copy the application pom.xml
+# -- This is the first app-specific piece --
 COPY ./user-app/pom.xml /project/user-app/pom.xml
 # Validate 
 RUN cd /project/user-app && ./validate.sh
+
 # Copy the rest of the application source
 COPY ./user-app/src /project/user-app/src
 
-# Build (and run unit tests); also liberty:create copies config from src->target
+# Build (and run unit tests) 
+#  also liberty:create copies config from src->target
 RUN cd /project/user-app && \
     mvn -B liberty:create package
 

--- a/incubator/java-openliberty/image/project/Dockerfile
+++ b/incubator/java-openliberty/image/project/Dockerfile
@@ -12,14 +12,28 @@ RUN cd /project && mvn -B install dependency:go-offline -DskipTests
 COPY ./util /project/util
 RUN  /project/util/check_version build
 
-# Copy the user's application pom and resolve all dependencies, also trigger Open Liberty install
-COPY ./user-app/pom.xml /project/user-app/pom.xml
-COPY ./validate.sh /project/user-app/validate.sh
-RUN cd /project/user-app && ./validate.sh
+#-----
+# Before copying any app file:
+#   - Prime .m2/repository with common artifacts 
+#   - Create target/liberty/wlp/usr/servers/defaultServer dir
+#-----
+COPY ./preload-m2-pom.xml /project/user-app/preload-m2-pom.xml
+RUN cd /project/user-app && \ 
+    mvn -B -f /project/user-app/preload-m2-pom.xml liberty:install-server dependency:resolve-plugins && \
+    rm /project/user-app/preload-m2-pom.xml
 
-# Copy and build the application source, and run unit tests
+COPY ./validate.sh /project/user-app/validate.sh
+
+# Copy the application pom.xml
+COPY ./user-app/pom.xml /project/user-app/pom.xml
+# Validate 
+RUN cd /project/user-app && ./validate.sh
+# Copy the rest of the application source
 COPY ./user-app/src /project/user-app/src
-RUN cd /project/user-app && mvn -B liberty:create package
+
+# Build (and run unit tests); also liberty:create copies config from src->target
+RUN cd /project/user-app && \
+    mvn -B liberty:create package
 
 RUN cd /project/user-app/target/liberty/wlp/usr/servers && \
     mkdir /config && \

--- a/incubator/java-openliberty/image/project/preload-m2-pom.xml
+++ b/incubator/java-openliberty/image/project/preload-m2-pom.xml
@@ -1,0 +1,123 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent><!--required parent POM-->
+        <groupId>dev.appsody</groupId>
+        <artifactId>java-openliberty</artifactId>
+        <version>{{.stack.parentpomrange}}</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>dev.appsody.starter.java-openliberty</groupId>
+    <artifactId>default</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <!-- Aggregate of MicroProfile APIs -->
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <version>3.2</version>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <!-- For tests -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-client</artifactId>
+            <version>3.2.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-extension-providers</artifactId>
+            <version>3.2.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.0.4</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Support for JDK 9 and above -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${version.maven-war-plugin}</version>
+            </plugin>
+            <!-- Enable liberty-maven plugin -->
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>${version.liberty-maven-plugin}</version>
+                <!-- Since we're mainly using the install dir layout and not actually running anything in stage 1, we don't
+                     hugely care what version of Open Liberty we install.   That seems like the kind of thing that could make
+                     somewhat a bit nervous, so we call this out here in this comment. -->
+                <configuration>
+                    <runtimeInstallDirectory>/project/user-app/target/liberty</runtimeInstallDirectory>
+                </configuration>
+            </plugin>
+            <!-- Plugin to run unit tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.maven-surefire-plugin}</version>
+            </plugin>
+            <!-- Plugin to run functional tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${version.maven-failsafe-plugin}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.1</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/incubator/java-openliberty/image/project/validate.sh
+++ b/incubator/java-openliberty/image/project/validate.sh
@@ -12,14 +12,19 @@ if [ ! -f ./pom.xml ]; then
   exit 1   
 fi
 
+M2_LOCAL_REPO=
+if [ ! -z "$APPSODY_DEV_MODE" ]; then
+    M2_LOCAL_REPO="-Dmaven.repo.local=/mvn/repository"
+fi
+
 # Get parent pom information (../pom.xml)
 args='export PARENT_GROUP_ID=${project.groupId}; export PARENT_ARTIFACT_ID=${project.artifactId}; export PARENT_VERSION=${project.version}
 export LIBERTY_GROUP_ID=${liberty.groupId}; export LIBERTY_ARTIFACT_ID=${liberty.artifactId}; export LIBERTY_VERSION=${version.openliberty-runtime}'
-eval $(mvn -q -Dexec.executable=echo -Dmaven.repo.local=/mvn/repository -Dexec.args="${args}" --non-recursive -f ../pom.xml exec:exec 2>/dev/null)
+eval $(mvn -q -Dexec.executable=echo $M2_LOCAL_REPO -Dexec.args="${args}" --non-recursive -f ../pom.xml exec:exec 2>/dev/null)
 
 # Install parent pom
 echo "Installing parent ${PARENT_GROUP_ID}:${PARENT_ARTIFACT_ID}:${PARENT_VERSION}"
-mvn install -Dmaven.repo.local=/mvn/repository -Denforcer.skip=true -f ../pom.xml
+mvn install  $M2_LOCAL_REPO -Denforcer.skip=true -f ../pom.xml
 
 # Get parent pom information
 a_groupId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:groupId" /project/pom.xml)

--- a/incubator/java-openliberty/image/project/validate.sh
+++ b/incubator/java-openliberty/image/project/validate.sh
@@ -12,6 +12,11 @@ if [ ! -f ./pom.xml ]; then
   exit 1   
 fi
 
+# 
+# During `appsody build`, we just want to use the same ~/.m2/repository with these mvn
+# commands that we use otherwise, so as to avoid extra downloads.  It's only during local dev
+# mode that we want to use /mvn/repository, mounted to the host ~/.m2/repository.
+#
 M2_LOCAL_REPO=
 if [ ! -z "$APPSODY_DEV_MODE" ]; then
     M2_LOCAL_REPO="-Dmaven.repo.local=/mvn/repository"

--- a/incubator/java-openliberty/stack.yaml
+++ b/incubator/java-openliberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Open Liberty
-version: 0.1.2
+version: 0.1.3
 description: Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Explanation:

This intends to do a few things to improve the overall performance of `appsody build` for the java-openliberty stack.

1.  Introduces a POM just for the purpose of priming the build's .m2/repository with MicroProfile and maven plugin dependencies. 
2.  Performs a Liberty install and server create before any application code is copied into the build
3.  Tweaks the validate.sh script to use the regular ~/.m2/repository during appsody build rather than the /mvn/repository it continues to use in run/debug/test.

### Summary (for release note):

* Improve performance of "appsody build" by layering a pre-populated mvn repository and an already-installed Open Liberty.