### PR TITLE
java-openliberty: use Junit 5 in default template

### DIFF
--- a/incubator/java-openliberty/README.md
+++ b/incubator/java-openliberty/README.md
@@ -37,6 +37,9 @@ OpenAPI endpoints:
 - http://localhost:9080/openapi (the RESTful APIs of the inventory service)
 - http://localhost:9080/openapi/ui (Swagger UI of the deployed APIs)
 
+Note: The default template uses JUnit 5. You may be used to JUnit 4, but here are some great reasons to make the switch https://developer.ibm.com/dwblog/2017/top-five-reasons-to-use-junit-5-java/
+
+
 ## Getting Started
 
 1. Create a new folder in your local directory and initialize it using the Appsody CLI, e.g.:

--- a/incubator/java-openliberty/stack.yaml
+++ b/incubator/java-openliberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Open Liberty
-version: 0.1.4
+version: 0.1.5
 description: Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java

--- a/incubator/java-openliberty/templates/default/pom.xml
+++ b/incubator/java-openliberty/templates/default/pom.xml
@@ -28,11 +28,12 @@
         </dependency>
         <!-- For tests -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.0</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-client</artifactId>

--- a/incubator/java-openliberty/templates/default/src/test/java/it/dev/appsody/starter/EndpointTest.java
+++ b/incubator/java-openliberty/templates/default/src/test/java/it/dev/appsody/starter/EndpointTest.java
@@ -13,17 +13,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class HealthEndpointTest {
+public class EndpointTest {
     
     private static String baseUrl;
-    private static final String LIVENESS_ENDPOINT = "/health/live";
-    private static final String READINESS_ENDPOINT = "/health/ready";
+    private static final String RESOURCE_ENDPOINT = "/starter/resource";
     private Client client;
     private Response response;
     
     @BeforeAll
     public static void oneTimeSetup() {
-        // Get test port property defined in pom.xml
         String port = System.getProperty("liberty.test.port");
         baseUrl = "http://localhost:" + port;
     }
@@ -42,31 +40,18 @@ public class HealthEndpointTest {
     }
 
     @Test
-    public void testLivenessEndpoint() {
-        checkHealthEndpoint(LIVENESS_ENDPOINT, "alive");
-
-    }
-    
-    @Test
-    public void testReadinessEndpoint() {
-        checkHealthEndpoint(READINESS_ENDPOINT, "ready");
+    public void testResourceEndpoint() {
+        checkEndpoint(RESOURCE_ENDPOINT, "StarterResource response");
 
     }
 
-    private void checkHealthEndpoint(String endpoint, String state) {
-        String healthURL = baseUrl + endpoint;
-        response = this.getResponse(healthURL);
-        this.assertResponse(healthURL, response);
+    private void checkEndpoint(String endpoint, String expectedResponseText) {
+        String resourceUrl = baseUrl + endpoint;
+        response = this.getResponse(resourceUrl);
+        this.assertResponse(resourceUrl, response);
         
-        JsonObject healthJson = response.readEntity(JsonObject.class);
-        
-        String expectedOutcome = "UP";
-        String actualOutcome = healthJson.getString("status");
-        assertEquals(expectedOutcome, actualOutcome, "Application should be " + state);
-        
-        actualOutcome = healthJson.getJsonArray("checks").getJsonObject(0).getString("status");
-        assertEquals(expectedOutcome, actualOutcome, "First array element was expected to be SystemResource and it wasn't healthy");
-    
+        String responseText = response.readEntity(String.class);
+        assertEquals(expectedResponseText, responseText, "Endpoint response text is not correct");
     }
     
     /**

--- a/incubator/java-openliberty/templates/default/src/test/java/it/dev/appsody/starter/HealthEndpointTest.java
+++ b/incubator/java-openliberty/templates/default/src/test/java/it/dev/appsody/starter/HealthEndpointTest.java
@@ -1,6 +1,6 @@
 package it.dev.appsody.starter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import javax.json.JsonObject;
 import javax.ws.rs.client.Client;
@@ -8,10 +8,10 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 
 import org.apache.cxf.jaxrs.provider.jsrjsonp.JsrJsonpProvider;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class HealthEndpointTest {
     
@@ -21,20 +21,20 @@ public class HealthEndpointTest {
     private Client client;
     private Response response;
     
-    @BeforeClass
+    @BeforeAll
     public static void oneTimeSetup() {
         String port = System.getProperty("liberty.test.port");
         baseUrl = "http://localhost:" + port;
     }
     
-    @Before
+    @BeforeEach
     public void setup() {
         response = null;
         client = ClientBuilder.newClient();
         client.register(JsrJsonpProvider.class);
     }
     
-    @After
+    @AfterEach
     public void teardown() {
         response.close();
         client.close();
@@ -61,10 +61,10 @@ public class HealthEndpointTest {
         
         String expectedOutcome = "UP";
         String actualOutcome = healthJson.getString("status");
-        assertEquals("Application should be " + state, expectedOutcome, actualOutcome);
+        assertEquals(expectedOutcome, actualOutcome, "Application should be " + state);
         
         actualOutcome = healthJson.getJsonArray("checks").getJsonObject(0).getString("status");
-        assertEquals("First array element was expected to be SystemResource and it wasn't healthy", expectedOutcome, actualOutcome);
+        assertEquals(expectedOutcome, actualOutcome, "First array element was expected to be SystemResource and it wasn't healthy");
     
     }
     
@@ -92,7 +92,7 @@ public class HealthEndpointTest {
      *          - response received from the target URL.
      */
     private void assertResponse(String url, Response response) {
-        assertEquals("Incorrect response code from " + url, 200, response.getStatus());
+        assertEquals(200, response.getStatus(), "Incorrect response code from " + url);
     }
 
 }


### PR DESCRIPTION
### Checklist:

- [ x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [ x] Updated the stack version in `stack.yaml`


Updated java-openliberty stack default template to use Junit 5 and added a basic endpoint test.


### Related Issues:
Fixes #595 

### Summary (for release notes)

Switch the default template application to use JUnit 5. 