### PR TITLE
Use environment variable for APPSODY_CLI_DOWNLOAD_URL if set

### DIFF
--- a/ci/download_cli.sh
+++ b/ci/download_cli.sh
@@ -9,7 +9,7 @@ then
     fi
     if [ -z "${APPSODY_CLI_DOWNLOAD_URL}" ]
     then
-        APPSODY_CLI_DOWNLOAD_URL=https://github.com/appsody/appsody/releases/download/
+        APPSODY_CLI_DOWNLOAD_URL=https://github.com/appsody/appsody/releases/download
     fi
     if [ -z "${APPSODY_CLI_FALLBACK}" ]
     then
@@ -32,7 +32,7 @@ then
     fi
 
     cli_deb="appsody_${release_tag}_amd64.deb"
-    cli_dist=https://github.com/appsody/appsody/releases/download/${release_tag}/${cli_deb}
+    cli_dist=${APPSODY_CLI_DOWNLOAD_URL}/${release_tag}/${cli_deb}
 
     echo " release_tag=${release_tag}"
     echo " cli_deb=${cli_deb}"


### PR DESCRIPTION
Signed-off-by: Steven Groeger <groeges@uk.ibm.com>

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
