### PR TITLE
java-openliberty: update LMP version to 3.2

### DIFF
--- a/incubator/java-openliberty/image/Dockerfile-stack
+++ b/incubator/java-openliberty/image/Dockerfile-stack
@@ -26,8 +26,7 @@ ENV APPSODY_MOUNTS="~/.m2/repository:/mvn/repository;.:/project/user-app"
 ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/target
 
-# Work around v3.1 issues with dev mode reacting to pom.xml change but should eventually not require this.
-ENV APPSODY_WATCH_REGEX="^pom\.xml$"
+ENV APPSODY_WATCH_REGEX=""
 
 ENV APPSODY_USER_RUN_AS_LOCAL=true
 
@@ -35,18 +34,13 @@ ENV APPSODY_USER_RUN_AS_LOCAL=true
 ENV APPSODY_PREP="export APPSODY_DEV_MODE=prep;  ../validate.sh"
 
 ENV APPSODY_RUN="export APPSODY_DEV_MODE=run; mvn -B -Pstack-image-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository package liberty:dev"
-# See ENV APPSODY_WATCH_REGEX comment
-ENV APPSODY_RUN_ON_CHANGE="export APPSODY_DEV_MODE=run; ../validate.sh && mvn -Pstack-image-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository package liberty:dev"
-ENV APPSODY_RUN_KILL=true
+ENV APPSODY_RUN_ON_CHANGE=""
 
 ENV APPSODY_DEBUG="export APPSODY_DEV_MODE=debug; mvn -B -Pstack-image-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository package liberty:dev"
-# See ENV APPSODY_WATCH_REGEX comment
-ENV APPSODY_DEBUG_ON_CHANGE="export APPSODY_DEV_MODE=debug; ../validate.sh && mvn -Pstack-image-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository package liberty:dev"
-ENV APPSODY_DEBUG_KILL=true
+ENV APPSODY_DEBUG_ON_CHANGE=""
 
 ENV APPSODY_TEST="export APPSODY_DEV_MODE=test; exec mvn -B -Pstack-image-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository clean package liberty:create liberty:install-feature liberty:start liberty:deploy failsafe:integration-test@it-exec liberty:stop failsafe:verify"
 ENV APPSODY_TEST_ON_CHANGE=""
-ENV APPSODY_TEST_KILL=true
 
 ENV PORT=9080
 

--- a/incubator/java-openliberty/image/Dockerfile-stack
+++ b/incubator/java-openliberty/image/Dockerfile-stack
@@ -23,24 +23,16 @@ WORKDIR /project/user-app
 
 ENV APPSODY_MOUNTS="~/.m2/repository:/mvn/repository;.:/project/user-app"
 
-ENV APPSODY_WATCH_DIR=/project/user-app
-ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/target
-
-ENV APPSODY_WATCH_REGEX=""
-
 ENV APPSODY_USER_RUN_AS_LOCAL=true
 
 # Set APPSODY_DEV_MODE to get in the habit in case we need it someday
 ENV APPSODY_PREP="export APPSODY_DEV_MODE=prep;  ../validate.sh"
 
 ENV APPSODY_RUN="export APPSODY_DEV_MODE=run; mvn -B -Pstack-image-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository package liberty:dev"
-ENV APPSODY_RUN_ON_CHANGE=""
 
 ENV APPSODY_DEBUG="export APPSODY_DEV_MODE=debug; mvn -B -Pstack-image-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository package liberty:dev"
-ENV APPSODY_DEBUG_ON_CHANGE=""
 
 ENV APPSODY_TEST="export APPSODY_DEV_MODE=test; exec mvn -B -Pstack-image-run -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository clean package liberty:create liberty:install-feature liberty:start liberty:deploy failsafe:integration-test@it-exec liberty:stop failsafe:verify"
-ENV APPSODY_TEST_ON_CHANGE=""
 
 ENV PORT=9080
 

--- a/incubator/java-openliberty/image/project/pom.xml
+++ b/incubator/java-openliberty/image/project/pom.xml
@@ -25,7 +25,7 @@
         <liberty.groupId>io.openliberty</liberty.groupId>
         <liberty.artifactId>openliberty-runtime</liberty.artifactId>
         <version.openliberty-runtime>{{.stack.libertyVersion}}</version.openliberty-runtime>
-        <version.liberty-maven-plugin>3.1</version.liberty-maven-plugin>
+        <version.liberty-maven-plugin>3.2</version.liberty-maven-plugin>
         <http.port>9080</http.port>
         <https.port>9443</https.port>
         <packaging.type>usr</packaging.type>
@@ -54,31 +54,44 @@
         </pluginManagement>
         <plugins>
             <!-- Enforcing OpenLiberty and JDK Version -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M2</version>
-                <executions>
-                <execution>
-                    <id>enforce-versions</id>
-                    <goals>
-                        <goal>enforce</goal>
-                    </goals>
-                    <configuration>
-                        <rules>
-                            <requireJavaVersion>
-                                <version>[1.8,1.9)</version>
-                            </requireJavaVersion>
-                            <requireProperty>
-                                <property>version.openliberty-runtime</property>
-                                <regex>{{.stack.libertyVersion}}</regex>
-                                <regexMessage>OpenLiberty runtime version must be {{.stack.libertyVersion}}</regexMessage>
-                            </requireProperty>
-                        </rules>
-                    </configuration>
-                </execution>
-            </executions>
-            </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.0.0-M3</version>
+				<executions>
+					<execution>
+						<id>default-cli</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireJavaVersion>
+									<version>[1.8,1.9)</version>
+								</requireJavaVersion>
+								<requireProperty>
+									<property>version.openliberty-runtime</property>
+									<regex>{{.stack.libertyVersion}}</regex>
+									<regexMessage>OpenLiberty runtime version must be {{.stack.libertyVersion}}</regexMessage>
+								</requireProperty>
+						
+								<!-- Restrict the Liberty Maven plugin version -->
+								<bannedPlugins>
+									<message>This project is only permitted to use Liberty Maven Plugin version ${version.liberty-maven-plugin} from io.openliberty.tools. i.e. io.openliberty.tools:liberty-maven-plugin:3.2</message>
+									<excludes>
+										<exclude>io.openliberty.tools:liberty-maven-plugin:*</exclude>
+										<exclude>net.wasdev.wlp.maven.plugins:liberty-maven-plugin:*</exclude>
+									</excludes>
+									<includes>
+										<include>io.openliberty.tools:liberty-maven-plugin:${version.liberty-maven-plugin}</include>
+									</includes>
+								</bannedPlugins>
+							</rules>
+							<fail>true</fail>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>

--- a/incubator/java-openliberty/image/project/validate.sh
+++ b/incubator/java-openliberty/image/project/validate.sh
@@ -22,6 +22,7 @@ if [ ! -z "$APPSODY_DEV_MODE" ]; then
     M2_LOCAL_REPO="-Dmaven.repo.local=/mvn/repository"
 fi
 
+
 # Get parent pom information (../pom.xml)
 args='export PARENT_GROUP_ID=${project.groupId}; export PARENT_ARTIFACT_ID=${project.artifactId}; export PARENT_VERSION=${project.version}
 export LIBERTY_GROUP_ID=${liberty.groupId}; export LIBERTY_ARTIFACT_ID=${liberty.artifactId}; export LIBERTY_VERSION=${version.openliberty-runtime}'

--- a/incubator/java-openliberty/stack.yaml
+++ b/incubator/java-openliberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Open Liberty
-version: 0.1.6
+version: 0.1.7
 description: Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Checklist:

- [ x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

* Update the Liberty Maven Plugin to version 3.2
* Add requirement in enforcer plugin to use LMP version 3.2



### Related Issues:
Fixes #608 

### Release Notes:
* Updates the Liberty Maven plugin version to 3.2