### PR TITLE
java-microprofile: upgrade OL version

### DIFF
--- a/incubator/java-microprofile/image/project/Dockerfile
+++ b/incubator/java-microprofile/image/project/Dockerfile
@@ -29,7 +29,7 @@ RUN cd /project/user-app/target && \
     mv wlp/usr/servers/*/* /config/
 
 # Step 2: Package Open Liberty image
-FROM open-liberty:kernel-java8-openj9
+FROM open-liberty:{{.stack.libertyversion}}-kernel-java8-openj9
 
 COPY --chown=1001:0 --from=0 /config/ /config/
 

--- a/incubator/java-microprofile/image/project/pom.xml
+++ b/incubator/java-microprofile/image/project/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>dev.appsody</groupId>
     <artifactId>java-microprofile</artifactId>
-    <version>0.2.22</version>
+    <version>0.2.23</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -30,7 +30,7 @@
         <!-- OpenLiberty runtime -->
         <liberty.groupId>io.openliberty</liberty.groupId>
         <liberty.artifactId>openliberty-runtime</liberty.artifactId>
-        <version.openliberty-runtime>19.0.0.8</version.openliberty-runtime>
+        <version.openliberty-runtime>{{.stack.libertyversion}}</version.openliberty-runtime>
         <http.port>9080</http.port>
         <https.port>9443</https.port>
         <packaging.type>usr</packaging.type>
@@ -66,8 +66,8 @@
                             </requireJavaVersion>
                             <requireProperty>
                                 <property>version.openliberty-runtime</property>
-                                <regex>19.0.0.8</regex>
-                                <regexMessage>OpenLiberty runtime version must be 19.0.0.8</regexMessage>
+                                <regex>{{.stack.libertyversion}}</regex>
+                                <regexMessage>OpenLiberty runtime version must be {{.stack.libertyversion}}</regexMessage>
                             </requireProperty>
                         </rules>
                     </configuration>

--- a/incubator/java-microprofile/stack.yaml
+++ b/incubator/java-microprofile/stack.yaml
@@ -1,5 +1,5 @@
 name: Eclipse MicroProfile®
-version: 0.2.22
+version: 0.2.23
 description: Eclipse MicroProfile on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java
@@ -14,3 +14,7 @@ maintainers:
     email: ozzy@ca.ibm.com
     github-id: BarDweller
 default-template: default
+requirements:
+    appsody-version: ">= 0.5.0"
+templating-data:
+    libertyversion: '19.0.0.12'


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

Update the java-microprofile stack to use Open Liberty version 19.0.0.12
Make the stack image version of OL consistent with the build image version of OL

### Related Issues:
Fixes #644 
