### PR TITLE
node-red: Bump stack version to put src and image in index

### DIFF
--- a/incubator/node-red/image/project/package.json
+++ b/incubator/node-red/image/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-stack",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Node-RED Stack",
   "license": "Apache-2.0",
   "repository": {

--- a/incubator/node-red/stack.yaml
+++ b/incubator/node-red/stack.yaml
@@ -1,5 +1,5 @@
 name: Node-RED
-version: 0.1.0
+version: 0.1.1
 description: Node-RED runtime for running flows
 license: Apache-2.0
 language: nodejs


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

We made some changes to the behaviour of appsody stack create and appsody stack package in the last release. Now, when you package your stack the fully qualified image is put in the index.yaml along with the source url of the stack. The latter will enable people to copy non public stacks when they run appsody stack create. This PR just bumps the version to put these values in.

cc @knolleary - Please take a look :) 
