### PR TITLE
python-flask: Bump stack version to put src and image in index

### DIFF
--- a/incubator/python-flask/image/Dockerfile-stack
+++ b/incubator/python-flask/image/Dockerfile-stack
@@ -13,6 +13,7 @@ ENV PATH=/home/worker/.local/bin:$PATH
 
 ENV APPSODY_MOUNTS=/:/project/userapp
 ENV APPSODY_DEPS=/project/deps
+ENV APPSODY_USER_RUN_AS_LOCAL=true
 
 ENV APPSODY_WATCH_DIR=/project/userapp
 ENV APPSODY_WATCH_REGEX="^.*.py$"

--- a/incubator/python-flask/stack.yaml
+++ b/incubator/python-flask/stack.yaml
@@ -1,5 +1,5 @@
 name: Python Flask
-version: 0.2.1
+version: 0.2.2
 description: Flask web Framework for Python
 language: python
 maintainers:


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

We made some changes to the behaviour of appsody stack create and appsody stack package in the last release. Now, when you package your stack the fully qualified image is put in the index.yaml along with the source url of the stack. The latter will enable people to copy non public stacks when they run appsody stack create. This PR just bumps the version to put these values in.

cc @henrynash - Please take a look :) 
