### PR TITLE
Remove liberty:create from stack image to avoid hardening pwd

### DIFF
--- a/incubator/java-openliberty/image/Dockerfile-stack
+++ b/incubator/java-openliberty/image/Dockerfile-stack
@@ -17,7 +17,7 @@ WORKDIR /project/
 
 RUN mkdir -p /mvn/repository
 RUN mvn -B -Dmaven.repo.local=/mvn/repository -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
-RUN mvn -B -Pstack-image-package -Dmaven.repo.local=/mvn/repository liberty:install-server liberty:create install dependency:go-offline
+RUN mvn -B -Pstack-image-package -Dmaven.repo.local=/mvn/repository liberty:install-server install dependency:go-offline
 RUN chmod -R 777 /opt/ol 
 
 

--- a/incubator/java-openliberty/stack.yaml
+++ b/incubator/java-openliberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Open Liberty
-version: 0.2.0
+version: 0.2.1
 description: Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Related Issues:

The quickStartSecurity password was wrongly baked into the stack image.    Removing so it is generated on each `appsody run/debug/test`.

(Note: this is the same as:  https://github.com/kabanero-io/collections/pull/272).