### PR TITLE
Add cli folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 **/00_local
 **/.DS_Store
 **/node_modules
+**/cli
 **/*.log
 **/target
 **/.settings


### PR DESCRIPTION
### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

In the travis step, the `download_cli.sh` creates a `cli/` folder. When the `appsody stack package` command runs, it retrieves git information that is added as labels to the stack image pushed to DockerHub. Since a new folder has been created, the label containing the git commit highlights this untrack change by adding a prefix `-modified` to the commit sha. 
To solve this, we add the `cli/` folder to the `.gitignore`.
