### PR TITLE
nodejs - Optimize copy for buildah

### DIFF
--- a/incubator/nodejs/image/project/Dockerfile
+++ b/incubator/nodejs/image/project/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update \
  && echo 'Finished installing dependencies'
 
 # Copying individual files/folders as buildah 1.9.0 does not honour .dockerignore
-COPY --chown=node:node package*.json /project/
-COPY --chown=node:node user-app /project/user-app
+COPY package*.json /project/
+COPY user-app /project/user-app
 # Removing node_modules as we can not make assumptions about file structure of user-app
  RUN rm -rf /project/user-app/node_modules && mkdir -p /project/user-app/node_modules
 

--- a/incubator/nodejs/image/project/Dockerfile
+++ b/incubator/nodejs/image/project/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
 RUN mkdir -p "/project/user-app/node_modules"
 WORKDIR "/project/user-app"
 COPY ./user-app/package*.json ./
-# Working around poor performance issue with buildah 1.9.0.
+# Working around poor performance issue with buildah 1.9.0 as it does not honour .dockerignore.
 # Once https://github.com/appsody/appsody-buildah/pull/14 is merged, we can remove the additional steps.
 RUN npm install --production && ls -al && tar czf app_modules.tgz node_modules
 
@@ -25,7 +25,7 @@ RUN apt-get update \
  && echo 'Finished installing dependencies'
 
 # Copy the project
-# Working around poor performance issue with buildah 1.9.0.
+# Working around poor performance issue with buildah 1.9.0 as it does not honour .dockerignore.
 # Once https://github.com/appsody/appsody-buildah/pull/14 is merged, we can remove the additional steps.
 COPY --chown=node:node package*.json /project
 COPY --chown=node:node user-app /project/user-app

--- a/incubator/nodejs/image/project/Dockerfile
+++ b/incubator/nodejs/image/project/Dockerfile
@@ -7,11 +7,12 @@ RUN apt-get update \
  && apt-get clean \
  && echo 'Finished installing dependencies'
 
-WORKDIR "/project/user-app/node_modules"
-
 # Install user-app dependencies
+RUN mkdir -p "/project/user-app/node_modules"
 WORKDIR "/project/user-app"
 COPY ./user-app/package*.json ./
+# Working around poor performance issue with buildah 1.9.0.
+# Once https://github.com/appsody/appsody-buildah/pull/14 is merged, we can remove the additional steps.
 RUN npm install --production && ls -al && tar czf app_modules.tgz node_modules
 
 # Copy the dependencies into a slim Node docker image
@@ -24,6 +25,8 @@ RUN apt-get update \
  && echo 'Finished installing dependencies'
 
 # Copy the project
+# Working around poor performance issue with buildah 1.9.0.
+# Once https://github.com/appsody/appsody-buildah/pull/14 is merged, we can remove the additional steps.
 COPY --chown=node:node package*.json /project
 COPY --chown=node:node user-app /project/user-app
 

--- a/incubator/nodejs/image/project/Dockerfile
+++ b/incubator/nodejs/image/project/Dockerfile
@@ -8,10 +8,9 @@ RUN apt-get update \
  && echo 'Finished installing dependencies'
 
 # Copying individual files/folders as buildah 1.9.0 does not honour .dockerignore
-COPY package*.json /project/
 COPY user-app /project/user-app
 # Removing node_modules as we can not make assumptions about file structure of user-app
- RUN rm -rf /project/user-app/node_modules && mkdir -p /project/user-app/node_modules
+RUN rm -rf /project/user-app/node_modules && mkdir -p /project/user-app/node_modules
 
 # Install user-app dependencies
 WORKDIR /project/user-app

--- a/incubator/nodejs/image/project/Dockerfile
+++ b/incubator/nodejs/image/project/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
 # Copy the project
 # Working around poor performance issue with buildah 1.9.0 as it does not honour .dockerignore.
 # Once https://github.com/appsody/appsody-buildah/pull/14 is merged, we can remove the additional steps.
-COPY --chown=node:node package*.json /project
+COPY --chown=node:node package*.json /project/
 COPY --chown=node:node user-app /project/user-app
 
 # Copy all dependencies

--- a/incubator/nodejs/image/project/Dockerfile
+++ b/incubator/nodejs/image/project/Dockerfile
@@ -7,11 +7,12 @@ RUN apt-get update \
  && apt-get clean \
  && echo 'Finished installing dependencies'
 
+WORKDIR "/project/user-app/node_modules"
+
 # Install user-app dependencies
 WORKDIR "/project/user-app"
 COPY ./user-app/package*.json ./
-RUN npm install --production
-WORKDIR "/project/user-app/node_modules"
+RUN npm install --production && ls -al && tar czf app_modules.tgz node_modules
 
 # Copy the dependencies into a slim Node docker image
 FROM node:12-slim
@@ -23,12 +24,13 @@ RUN apt-get update \
  && echo 'Finished installing dependencies'
 
 # Copy the project
-COPY --chown=node:node . /project
+COPY --chown=node:node package*.json /project
+COPY --chown=node:node user-app /project/user-app
 
 # Copy all dependencies
-COPY --chown=node:node --from=0 /project/user-app/node_modules /project/user-app/node_modules
-
 WORKDIR "/project/user-app"
+COPY --chown=node:node --from=0 /project/user-app/app_modules.tgz .
+RUN tar xf app_modules.tgz && chown -R node:node node_modules && rm app_modules.tgz
 
 ENV NODE_ENV production
 

--- a/incubator/nodejs/image/project/Dockerfile
+++ b/incubator/nodejs/image/project/Dockerfile
@@ -7,13 +7,18 @@ RUN apt-get update \
  && apt-get clean \
  && echo 'Finished installing dependencies'
 
+# Copying individual files/folders as buildah 1.9.0 does not honour .dockerignore
+COPY --chown=node:node package*.json /project/
+COPY --chown=node:node user-app /project/user-app
+# Removing node_modules as we can not make assumptions about file structure of user-app
+ RUN rm -rf /project/user-app/node_modules && mkdir -p /project/user-app/node_modules
+
 # Install user-app dependencies
-RUN mkdir -p "/project/user-app/node_modules"
-WORKDIR "/project/user-app"
-COPY ./user-app/package*.json ./
-# Working around poor performance issue with buildah 1.9.0 as it does not honour .dockerignore.
-# Once https://github.com/appsody/appsody-buildah/pull/14 is merged, we can remove the additional steps.
-RUN npm install --production && ls -al && tar czf app_modules.tgz node_modules
+WORKDIR /project/user-app
+RUN npm install --production 
+
+# Creating a tar to work around poor copy performance when using buildah 1.9.0
+RUN cd / && tar czf project.tgz project
 
 # Copy the dependencies into a slim Node docker image
 FROM node:12-slim
@@ -24,16 +29,11 @@ RUN apt-get update \
  && apt-get clean \
  && echo 'Finished installing dependencies'
 
-# Copy the project
-# Working around poor performance issue with buildah 1.9.0 as it does not honour .dockerignore.
-# Once https://github.com/appsody/appsody-buildah/pull/14 is merged, we can remove the additional steps.
-COPY --chown=node:node package*.json /project/
-COPY --chown=node:node user-app /project/user-app
+# Copy project with dependencies
+COPY --chown=node:node --from=0 /project.tgz .
+RUN tar xf project.tgz && chown -R node:node project && rm project.tgz
 
-# Copy all dependencies
-WORKDIR "/project/user-app"
-COPY --chown=node:node --from=0 /project/user-app/app_modules.tgz .
-RUN tar xf app_modules.tgz && chown -R node:node node_modules && rm app_modules.tgz
+WORKDIR /project/user-app
 
 ENV NODE_ENV production
 

--- a/incubator/nodejs/image/project/package.json
+++ b/incubator/nodejs/image/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Node.js Stack",
   "license": "Apache-2.0",
   "repository": {

--- a/incubator/nodejs/stack.yaml
+++ b/incubator/nodejs/stack.yaml
@@ -1,5 +1,5 @@
 name: Node.js
-version: 0.3.3
+version: 0.3.4
 description: Runtime for Node.js applications
 license: Apache-2.0
 language: nodejs


### PR DESCRIPTION
We are seeing significant performance issues with all Node.js based stacks to build the final application image when using buildah (instead of docker).

This is because of a known issue with buildah 1.9.0. We can not upgrade the buildah version because of other issues. 

This is a temporary fix to optimize the number of files we copy during the build process.

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
