### PR TITLE
Add ARG to stack Dockerfiles to allow appsody to pass docker-options for build-arg JAVA_OPTIONS - WIP DO NOT MERGE

### DIFF
--- a/incubator/java-microprofile/image/project/Dockerfile
+++ b/incubator/java-microprofile/image/project/Dockerfile
@@ -1,6 +1,9 @@
 # Step 1: Build the user's application
 FROM adoptopenjdk/openjdk8-openj9 as compile
 
+# Allow appsody deploy to set --build-arg for an env variable
+ARG IBM_JAVA_OPTIONS
+
 RUN apt-get update && \
     apt-get install -y maven unzip wget xmlstarlet
 
@@ -33,6 +36,9 @@ RUN cd /project/user-app/target && \
 
 # Step 2: Package Open Liberty image
 FROM open-liberty:{{.stack.libertyversion}}-kernel-java8-openj9
+
+# Allow appsody deploy to set --build-arg for an env variable
+ARG IBM_JAVA_OPTIONS
 
 COPY --chown=1001:0 --from=compile /config/ /config/
 

--- a/incubator/java-microprofile/image/project/Dockerfile
+++ b/incubator/java-microprofile/image/project/Dockerfile
@@ -1,9 +1,6 @@
 # Step 1: Build the user's application
 FROM adoptopenjdk/openjdk8-openj9 as compile
 
-# Allow appsody deploy to set --build-arg for an env variable
-ARG IBM_JAVA_OPTIONS
-
 RUN apt-get update && \
     apt-get install -y maven unzip wget xmlstarlet
 


### PR DESCRIPTION
### Checklist:

- [ ] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ ] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
