### PR TITLE
openliberty - Add ARG to stack Dockerfiles to allow appsody to pass docker-options for build-arg JAVA_OPTIONS

### DIFF
--- a/incubator/java-openliberty/image/project/Dockerfile
+++ b/incubator/java-openliberty/image/project/Dockerfile
@@ -60,6 +60,9 @@ RUN cd /project/user-app/target/liberty/wlp/usr/servers && \
 # Step 2: Package Open Liberty image
 FROM openliberty/open-liberty:{{.stack.libertyversion}}-kernel-java8-openj9-ubi
 
+# Allow appsody deploy to set --build-arg for an env variable
+ARG IBM_JAVA_OPTIONS
+
 #2a) copy any resources 
 COPY --chown=1001:0 --from=compile /shared /opt/ol/wlp/usr/shared/
 

--- a/incubator/java-openliberty/stack.yaml
+++ b/incubator/java-openliberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Open Liberty
-version: 0.2.1
+version: 0.2.2
 description: Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->
We are adding the IBM_JAVA_OPTION to dockerfile so when appsody --docker-options pass --build-args to docker build for apps under development, JAVA_OPTIONS for OpenJ9 jvm are available in the liberty app container that runs on openshift/k8s. This not only helps our appsody goals but all real enterprise application configuration. This allows customers to pass all kinds of options they would need to set to be able to run a real enterprise app. The actual passing of args via appsody is still difficult given all the escape sequences that need to be used. 

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
https://github.com/appsody/appsody/issues/900