### PR TITLE
Perform mvn install as java_user

### DIFF
--- a/incubator/java-openliberty/image/Dockerfile-stack
+++ b/incubator/java-openliberty/image/Dockerfile-stack
@@ -11,6 +11,8 @@ COPY ./LICENSE /licenses/
 COPY --chown=java_user:java_group ./project /project
 COPY --chown=java_user:java_group ./config /config
 
+USER java_user
+
 RUN  /project/util/check_version build
 
 WORKDIR /project/
@@ -22,8 +24,6 @@ RUN chmod -R 777 /opt/ol
 
 
 WORKDIR /project/user-app
-
-USER java_user
 
 ENV APPSODY_MOUNTS="~/.m2/repository:/mvn/repository;.:/project/user-app"
 

--- a/incubator/java-openliberty/stack.yaml
+++ b/incubator/java-openliberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Open Liberty
-version: 0.2.1
+version: 0.2.2
 description: Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

### Checklist:
* Switch to java_user in stack build, before doing maven installs.

### Related Issues:
Fixes #678
