### PR TITLE
kitura: ensure .appsody folder exists in container

### DIFF
--- a/incubator/kitura/image/Dockerfile-stack
+++ b/incubator/kitura/image/Dockerfile-stack
@@ -17,7 +17,7 @@ ENV APPSODY_WATCH_IGNORE_DIR="/project/user-app/.build;/project/user-app/.appsod
 ENV APPSODY_WATCH_REGEX="^.*.swift$"
 
 # Re-copy project dependencies from base image, if they have been modified
-ENV APPSODY_PREP="if [ -n \"$(diff -rq /project/deps /project/user-app/.appsody)\" ]; then rm -rf /project/user-app/.appsody && cp -R -p /project/deps /project/user-app/.appsody; fi"
+ENV APPSODY_PREP="if [ ! -d /project/user-app/.appsody ] && [ -n \"$(diff -rq /project/deps /project/user-app/.appsody)\" ]; then rm -rf /project/user-app/.appsody && cp -R -p /project/deps /project/user-app/.appsody; fi"
 
 ENV APPSODY_RUN="swift run"
 ENV APPSODY_RUN_ON_CHANGE="swift run"

--- a/incubator/kitura/image/Dockerfile-stack
+++ b/incubator/kitura/image/Dockerfile-stack
@@ -17,7 +17,7 @@ ENV APPSODY_WATCH_IGNORE_DIR="/project/user-app/.build;/project/user-app/.appsod
 ENV APPSODY_WATCH_REGEX="^.*.swift$"
 
 # Re-copy project dependencies from base image, if they have been modified
-ENV APPSODY_PREP="if [ ! -d /project/user-app/.appsody ] && [ -n \"$(diff -rq /project/deps /project/user-app/.appsody)\" ]; then rm -rf /project/user-app/.appsody && cp -R -p /project/deps /project/user-app/.appsody; fi"
+ENV APPSODY_PREP="if [ ! -d /project/user-app/.appsody ] || [ -n \"$(diff -rq /project/deps /project/user-app/.appsody)\" ]; then rm -rf /project/user-app/.appsody && cp -R -p /project/deps /project/user-app/.appsody; fi"
 
 ENV APPSODY_RUN="swift run"
 ENV APPSODY_RUN_ON_CHANGE="swift run"

--- a/incubator/kitura/stack.yaml
+++ b/incubator/kitura/stack.yaml
@@ -1,5 +1,5 @@
 name: Kitura
-version: 0.2.4
+version: 0.2.5
 description: Runtime for Kitura applications
 license: Apache-2.0
 language: swift


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

Copies `/project/deps` folder to `/project/user-app/.appsody` in the container if it doesn't exist in the user's project (because the init script failed)

### Related Issues:
Fixes #610 
