### PR TITLE
rust: Update version to rerelease stack

### DIFF
--- a/experimental/rust/stack.yaml
+++ b/experimental/rust/stack.yaml
@@ -1,5 +1,5 @@
 name: Rust
-version: 0.1.5
+version: 0.1.6
 description: Runtime for Rust applications
 license: Apache-2.0
 language: rust


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

There was a bug causing a few stacks released in the past couple of days to not be pushed to Docker hub. This PR bumps the version so that we can release the stacks properly.
