### PR TITLE
nodejs-express: change back into /project dir at the end of build

### DIFF
--- a/incubator/nodejs-express/image/project/Dockerfile
+++ b/incubator/nodejs-express/image/project/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
 # Copy project with dependencies
 COPY --chown=node:node --from=0 /project.tgz /
 RUN tar xf project.tgz && chown -R node:node /project && rm project.tgz
+WORKDIR /project
 
 ENV NODE_PATH=/project/user-app/node_modules
 

--- a/incubator/nodejs-express/image/project/package.json
+++ b/incubator/nodejs-express/image/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-express",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Node.js Express Stack",
   "license": "Apache-2.0",
   "repository": {

--- a/incubator/nodejs-express/stack.yaml
+++ b/incubator/nodejs-express/stack.yaml
@@ -1,5 +1,5 @@
 name: Node.js Express
-version: 0.4.3
+version: 0.4.4
 description: Express web framework for Node.js
 license: Apache-2.0
 language: nodejs


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

Because we don't change directory back into /project, there was an error when running the built image as no package.json could be found. This (hopefully) fixes that.

cc @sam-github 

### Related Issues:
Fixes: https://github.com/appsody/stacks/issues/696
