### PR TITLE
Update to build nodejs-express stack as non-root

### DIFF
--- a/incubator/nodejs-express/image/Dockerfile-stack
+++ b/incubator/nodejs-express/image/Dockerfile-stack
@@ -1,5 +1,7 @@
 FROM appsody/nodejs:0.3
 
+RUN useradd --gid 0 --shell /bin/bash --create-home node_user
+
 ENV APPSODY_PROJECT_DIR=/project
 ENV APPSODY_MOUNTS=/:/project/user-app
 ENV APPSODY_DEPS=/project/user-app/node_modules
@@ -23,9 +25,16 @@ ENV APPSODY_TEST_ON_CHANGE=""
 ENV APPSODY_TEST_KILL=false
 
 COPY ./LICENSE /licenses/
-COPY ./project /project
-COPY ./config /config
+COPY --chown=node_user:0 ./project /project
+COPY --chown=node_user:0 ./config /config
+
 WORKDIR /project
+
+RUN mkdir -p /project/user-app/node_modules \
+ && chmod -R g=u /project
+
+USER node_user
+ 
 RUN npm install && npm audit fix
 
 ENV PORT=3000

--- a/incubator/nodejs-express/image/project/Dockerfile
+++ b/incubator/nodejs-express/image/project/Dockerfile
@@ -7,12 +7,19 @@ RUN apt-get update \
  && apt-get clean \
  && echo 'Finished installing dependencies'
 
+RUN useradd --gid 0 --shell /bin/bash --create-home node_user
+
 # Copying individual files/folders as buildah 1.9.0 does not honour .dockerignore
 COPY package*.json /project/
 COPY *.js /project/
 COPY user-app /project/user-app
 # Removing node_modules as we can not make assumptions about file structure of user-app
 RUN rm -rf /project/user-app/node_modules && mkdir -p /project/user-app/node_modules
+
+RUN chown -hR node_user:0 /project \
+ && chmod -R g=u /project
+
+USER node_user
 
 # Install stack dependencies
 WORKDIR /project
@@ -22,11 +29,15 @@ RUN npm install --production
 WORKDIR /project/user-app
 RUN npm install --production
 
+USER root
+
 # Creating a tar to work around poor copy performance when using buildah 1.9.0
 RUN cd / && tar czf project.tgz project
 
 # Copy the dependencies into a slim Node docker image
 FROM node:12-slim
+
+RUN useradd --gid 0 --shell /bin/bash --create-home node_user
 
 # Install OS updates
 RUN apt-get update \
@@ -35,8 +46,13 @@ RUN apt-get update \
  && echo 'Finished installing dependencies'
 
 # Copy project with dependencies
-COPY --chown=node:node --from=0 /project.tgz /
-RUN tar xf project.tgz && chown -R node:node /project && rm project.tgz
+COPY --from=0 /project.tgz /
+
+RUN tar xf project.tgz  \
+ && chown -R node_user:0 /project \
+ && chmod -R g=u /project \
+ && rm project.tgz
+ 
 WORKDIR /project
 
 ENV NODE_PATH=/project/user-app/node_modules
@@ -44,7 +60,7 @@ ENV NODE_PATH=/project/user-app/node_modules
 ENV NODE_ENV production
 ENV PORT 3000
 
-USER node
+USER node_user
 
 EXPOSE 3000
 CMD ["npm", "start"]


### PR DESCRIPTION
Signed-off-by: Steven Groeger <groeges@uk.ibm.com>

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:
Updates to Dockerfiles to allow stacks to be built as non-root

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
