### PR TITLE
bump spring boot stack spring version to 2.1.12

### DIFF
--- a/incubator/java-spring-boot2/image/project/appsody-boot2-pom.xml
+++ b/incubator/java-spring-boot2/image/project/appsody-boot2-pom.xml
@@ -33,12 +33,12 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-dependencies</artifactId>
-    <version>2.1.6.RELEASE</version>
+    <version>2.1.12.RELEASE</version>
   </parent>
 
   <properties>
     <!-- Required library versions -->
-    <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
+    <spring-boot.version>2.1.12.RELEASE</spring-boot.version>
     <opentracing-spring-jaeger-web-starter.version>2.0.0</opentracing-spring-jaeger-web-starter.version>
 
     <java.version>1.8</java.version>

--- a/incubator/java-spring-boot2/image/project/appsody-boot2-snowdrop-pom.xml
+++ b/incubator/java-spring-boot2/image/project/appsody-boot2-snowdrop-pom.xml
@@ -58,11 +58,10 @@
 
   <properties>
     <!-- Required library versions -->
-    <spring-boot-bom.version>2.1.6.SP3-redhat-00001</spring-boot-bom.version>
-    <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
-
-    <opentracing-spring-jaeger-web-starter.version>2.0.0</opentracing-spring-jaeger-web-starter.version>
-
+    
+    <spring-boot-bom.version>2.1.12.Final-redhat-00001</spring-boot-bom.version>
+    <spring-boot.version>2.1.12.RELEASE</spring-boot.version>
+    
     <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -81,7 +80,7 @@
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-		<maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
+		<maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
 		<maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
 		<maven-install-plugin.version>2.5.2</maven-install-plugin.version>
 		<maven-invoker-plugin.version>3.1.0</maven-invoker-plugin.version>
@@ -138,7 +137,6 @@
     <dependency>
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
-      <version>${opentracing-spring-jaeger-web-starter.version}</version>
     </dependency>
   </dependencies>
 

--- a/incubator/java-spring-boot2/stack.yaml
+++ b/incubator/java-spring-boot2/stack.yaml
@@ -1,5 +1,5 @@
 name: Spring Boot®
-version: 0.3.26
+version: 0.3.27
 description: Spring Boot using OpenJ9 and Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [X] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [X] Updated the stack version in `stack.yaml`

Update stack parent pom for newer spring boot fix level.

### Related Issues:
review spring boot stack's spring boot version for 03/2020
https://github.ibm.com/ibmcloud/spring-at-ibm/issues/141