### PR TITLE
java-openliberty:keystore.xml perms not set correctly

### DIFF
--- a/incubator/java-openliberty/image/project/Dockerfile
+++ b/incubator/java-openliberty/image/project/Dockerfile
@@ -73,5 +73,6 @@ COPY --chown=1001:0 --from=compile /config/ /config/
 
 # 2d) Changes to the application binary
 COPY --chown=1001:0 --from=compile /project/user-app/target/*.[ew]ar /config/apps
-
+USER root
 RUN configure.sh
+USER 1001

--- a/incubator/java-openliberty/image/project/Dockerfile
+++ b/incubator/java-openliberty/image/project/Dockerfile
@@ -73,6 +73,5 @@ COPY --chown=1001:0 --from=compile /config/ /config/
 
 # 2d) Changes to the application binary
 COPY --chown=1001:0 --from=compile /project/user-app/target/*.[ew]ar /config/apps
-USER root
-RUN configure.sh
-USER 1001
+RUN configure.sh && \
+    chmod 664 /opt/ol/wlp/usr/servers/defaultServer/configDropins/defaults/keystore.xml

--- a/incubator/java-openliberty/stack.yaml
+++ b/incubator/java-openliberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Open Liberty
-version: 0.2.2
+version: 0.2.3
 description: Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->