### PR TITLE
nodejs: Stack use only package versions defined in base image

### DIFF
--- a/incubator/nodejs/image/Dockerfile-stack
+++ b/incubator/nodejs/image/Dockerfile-stack
@@ -8,7 +8,7 @@ ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/node_modules
 ENV APPSODY_WATCH_REGEX="^.*.js$"
 
-ENV APPSODY_PREP="npm install && npm audit fix"
+ENV APPSODY_PREP="npm install"
 
 ENV APPSODY_RUN="npm start --node-options --require=appmetrics-dash/attach"
 ENV APPSODY_RUN_ON_CHANGE="npm start --node-options --require=appmetrics-dash/attach"
@@ -27,7 +27,7 @@ COPY ./project /project
 COPY ./config /config
 
 WORKDIR /project
-RUN npm install && npm audit fix
+RUN npm install
 
 WORKDIR /project/user-app
 

--- a/incubator/nodejs/image/project/Dockerfile
+++ b/incubator/nodejs/image/project/Dockerfile
@@ -1,12 +1,6 @@
 # Install the app dependencies in a full Node docker image
 FROM node:12
 
-# Install OS updates
-RUN apt-get update \
- && apt-get dist-upgrade -y \
- && apt-get clean \
- && echo 'Finished installing dependencies'
-
 # Copying individual files/folders as buildah 1.9.0 does not honour .dockerignore
 COPY user-app /project/user-app
 # Removing node_modules as we can not make assumptions about file structure of user-app
@@ -21,12 +15,6 @@ RUN cd / && tar czf project.tgz project
 
 # Copy the dependencies into a slim Node docker image
 FROM node:12-slim
-
-# Install OS updates
-RUN apt-get update \
- && apt-get dist-upgrade -y \
- && apt-get clean \
- && echo 'Finished installing dependencies'
 
 # Copy project with dependencies
 COPY --chown=node:node --from=0 /project.tgz .

--- a/incubator/nodejs/image/project/package.json
+++ b/incubator/nodejs/image/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Node.js Stack",
   "license": "Apache-2.0",
   "repository": {

--- a/incubator/nodejs/stack.yaml
+++ b/incubator/nodejs/stack.yaml
@@ -1,5 +1,5 @@
 name: Node.js
-version: 0.3.4
+version: 0.3.5
 description: Runtime for Node.js applications
 license: Apache-2.0
 language: nodejs


### PR DESCRIPTION
Signed-off-by: Steven Groeger <groeges@uk.ibm.com>

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
