### PR TITLE
Change ci-timeout from 40 mins to 60 mins

### DIFF
--- a/ci/env.sh
+++ b/ci/env.sh
@@ -130,7 +130,7 @@ logged() {
     if [ "${CI_WAIT_FOR}" = "true" ]
     then
         # check every 30 seconds for a max of 40 minutes
-        $script_dir/ci_wait.sh --interval 30 --limit 2400 --append 1 --output "$log" $@
+        $script_dir/ci_wait.sh --interval 30 --limit 3600 --append 1 --output "$log" $@
     elif [ -n "${CI_WAIT_FOR}" ]
     then
         # custom interval/limit for environment


### PR DESCRIPTION
Increased the ci timeout from 40 mins to 60 mins as some stacks can take longer to validate.

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

