### PR TITLE
nodejs-express: require appmetrics prometheus earlier in server.js

### DIFF
--- a/incubator/nodejs-express/image/project/package.json
+++ b/incubator/nodejs-express/image/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-express",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Node.js Express Stack",
   "license": "Apache-2.0",
   "repository": {

--- a/incubator/nodejs-express/image/project/server.js
+++ b/incubator/nodejs-express/image/project/server.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const health = require('@cloudnative/health-connect');
+const metrics = require('appmetrics-prometheus')
 const fs = require('fs');
 const http = require('http');
 
 const app = express();
+app.use('/metrics', metrics.endpoint());
 const server = http.createServer(app)
 
 // Code sensitive to production vs development mode.
@@ -42,7 +44,6 @@ const healthcheck = new health.HealthChecker();
 app.use('/live', health.LivenessEndpoint(healthcheck));
 app.use('/ready', health.ReadinessEndpoint(healthcheck));
 app.use('/health', health.HealthEndpoint(healthcheck));
-app.use('/metrics', require('appmetrics-prometheus').endpoint());
 
 app.get('*', (req, res) => {
   res.status(404).send("Not Found");

--- a/incubator/nodejs-express/stack.yaml
+++ b/incubator/nodejs-express/stack.yaml
@@ -1,5 +1,5 @@
 name: Node.js Express
-version: 0.4.5
+version: 0.4.6
 description: Express web framework for Node.js
 license: Apache-2.0
 language: nodejs


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

Previously, `appmetrics=prometheus` was being loaded too late in the production build and therefore some metrics were lost. After changes (we can see more than just os metrics again):
```
# HELP os_cpu_used_ratio The ratio of the systems CPU that is currently used (values are 0-1)
# TYPE os_cpu_used_ratio gauge
os_cpu_used_ratio 0.0621999
# HELP process_cpu_used_ratio The ratio of the process CPU that is currently used (values are 0-1)
# TYPE process_cpu_used_ratio gauge
process_cpu_used_ratio 0.000555356
# HELP os_resident_memory_bytes OS memory size in bytes.
# TYPE os_resident_memory_bytes gauge
os_resident_memory_bytes 1989357568
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 65122304
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 1277386752
# HELP http_requests_total Total number of HTTP requests made.
# TYPE http_requests_total counter
http_requests_total{code="200", handler="/metrics", method="get"} 6
# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
# TYPE http_request_duration_microseconds summary
http_request_duration_microseconds{handler="/metrics",quantile="0.5"} 0.5419
http_request_duration_microseconds{handler="/metrics",quantile="0.9"} 6.9138
http_request_duration_microseconds{handler="/metrics",quantile="0.99"} 6.9138
http_request_duration_microseconds_sum{handler="/metrics"} 9.5546
http_request_duration_microseconds_count{handler="/metrics"} 6
```


### Related Issues:
Fixes: https://github.com/appsody/stacks/issues/725
