### PR TITLE
Fix download cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ go:
 os: linux
 dist: bionic
 
+env:
+  - GITHUB_READ_TOKEN: "05a26637e299a0d3481c9f9c62c8d5a373c74af9"
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ go:
 os: linux
 dist: bionic
 
-env:
-  - GITHUB_READ_TOKEN: "05a26637e299a0d3481c9f9c62c8d5a373c74af9"
-
 services:
   - docker
 

--- a/ci/download_cli.sh
+++ b/ci/download_cli.sh
@@ -22,7 +22,7 @@ then
     cli_dir=$base_dir/cli
     mkdir -p $cli_dir
 
-    curl -H "Authorization: token ${GH_TOKEN}" -L -s -o $cli_dir/release.json "$APPSODY_CLI_RELEASE_URL"
+    curl -H "Authorization: token ${GITHUB_READ_TOKEN}" -L -s -o $cli_dir/release.json "$APPSODY_CLI_RELEASE_URL"
     release_tag=$(cat $cli_dir/release.json | grep "tag_name" | cut -d'"' -f4)
     if ! [[ "$release_tag" =~ [0-9]+\.[0-9]+\.[0-9]+ ]]
     then
@@ -38,6 +38,6 @@ then
     echo " cli_deb=${cli_deb}"
     echo " cli_dist=${cli_dist}"
 
-    curl -H "Authorization: token ${GH_TOKEN}" -L -s -o "$cli_dir/$cli_deb" "$cli_dist"
+    curl -H "Authorization: token ${GITHUB_READ_TOKEN}" -L -s -o "$cli_dir/$cli_deb" "$cli_dist"
     sudo dpkg -i $cli_dir/$cli_deb
 fi

--- a/ci/download_cli.sh
+++ b/ci/download_cli.sh
@@ -22,7 +22,7 @@ then
     cli_dir=$base_dir/cli
     mkdir -p $cli_dir
 
-    curl -L -s -o $cli_dir/release.json "$APPSODY_CLI_RELEASE_URL"
+    curl -H "Authorization: token ${GH_TOKEN}" -L -s -o $cli_dir/release.json "$APPSODY_CLI_RELEASE_URL"
     release_tag=$(cat $cli_dir/release.json | grep "tag_name" | cut -d'"' -f4)
     if ! [[ "$release_tag" =~ [0-9]+\.[0-9]+\.[0-9]+ ]]
     then
@@ -38,6 +38,6 @@ then
     echo " cli_deb=${cli_deb}"
     echo " cli_dist=${cli_dist}"
 
-    curl -L -s -o "$cli_dir/$cli_deb" "$cli_dist"
+    curl -H "Authorization: token ${GH_TOKEN}" -L -s -o "$cli_dir/$cli_deb" "$cli_dist"
     sudo dpkg -i $cli_dir/$cli_deb
 fi

--- a/ci/download_cli.sh
+++ b/ci/download_cli.sh
@@ -13,7 +13,7 @@ then
     fi
     if [ -z "${APPSODY_CLI_FALLBACK}" ]
     then
-        APPSODY_CLI_FALLBACK=0.5.4
+        APPSODY_CLI_FALLBACK=0.5.9
     fi
 
     script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).


### Issue
Travis is hitting a limit of https requests to Github to download the CLI. Adding read only token to increase this limit.
