### PR TITLE
java-openliberty: add serverStartTimeout config to stack pom

### DIFF
--- a/incubator/java-openliberty/image/project/pom.xml
+++ b/incubator/java-openliberty/image/project/pom.xml
@@ -48,7 +48,9 @@
                     <groupId>io.openliberty.tools</groupId>
                     <artifactId>liberty-maven-plugin</artifactId>
                     <version>${version.liberty-maven-plugin}</version>
-                    <!--  No common plugin configuration currently in this stack, but it could be added here. -->
+                    <configuration>
+                        <serverStartTimeout>120</serverStartTimeout>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/incubator/java-openliberty/stack.yaml
+++ b/incubator/java-openliberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Open Liberty
-version: 0.2.4
+version: 0.2.5
 description: Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Checklist:

- [x ] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x ] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [ x] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

Add `serverStartTimeout` property to parent pom to provide a larger timeout for non-template projects. 

### Related Issues:
Fixes #694 
