### PR TITLE
Swift: Preserve build path between build and run stages

### DIFF
--- a/incubator/swift/README.md
+++ b/incubator/swift/README.md
@@ -52,7 +52,7 @@ You can enable an existing project as follows:
 2. Initialize your Appsody project with the Swift stack, but without a template:
 
     ```bash
-    appsody init swift --no-template
+    appsody init swift none
     ```
 
 3. After your project has been initialized you can then run your application using the following command:

--- a/incubator/swift/image/project/Dockerfile
+++ b/incubator/swift/image/project/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
  && echo 'Finished installing dependencies'
 
 # Install user-app dependencies
-WORKDIR "/project/user-app"
+WORKDIR "/project"
 COPY ./user-app ./
 
 # Build project, and discover executable name
@@ -25,8 +25,8 @@ RUN apt-get update \
  && echo 'Finished installing dependencies'
 
 WORKDIR "/project"
-COPY --from=builder /project/user-app/.build /project/.build
-COPY --from=builder /project/user-app/run.sh /project
+COPY --from=builder /project/.build /project/.build
+COPY --from=builder /project/run.sh /project
 
 ENV PORT 8080
 EXPOSE 8080

--- a/incubator/swift/stack.yaml
+++ b/incubator/swift/stack.yaml
@@ -1,5 +1,5 @@
 name: Swift
-version: 0.2.5
+version: 0.2.6
 description: Appsody runtime for Swift applications
 license: Apache-2.0
 language: swift


### PR DESCRIPTION
Avoids swift `#file` paths being invalid when used to look up relative paths to resources.

This was resulting in Kitura's `FileResourceServer` logging errors (due to a design flaw) when the initial landing page is viewed after embedding an existing Kitura project into a project based on the `swift` stack.

### Checklist:

- [ ] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ ] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
