### PR TITLE
java-openliberty: update OpenLiberty stack to use OpenLibertyApplication

### DIFF
--- a/incubator/java-openliberty/README.md
+++ b/incubator/java-openliberty/README.md
@@ -8,6 +8,18 @@ This stack is based on OpenJDK with container-optimizations in OpenJ9 and `Open 
 
 **Note:** Maven is provided by the Appsody stack container, allowing you to build, test, and debug your Java application without installing Maven locally. However, we recommend installing Maven locally for the best IDE experience.
 
+
+## Prerequisites
+
+This stack requires the [Open Liberty Operator](https://github.com/OpenLiberty/open-liberty-operator) to be installed in the cluster prior to deploying the stack.
+
+Operator user guide can be viewed [here](https://github.com/OpenLiberty/open-liberty-operator/blob/master/doc/user-guide.md)
+
+Aside from `OpenLibertyApplication` CRD used to deploy the application, Open Liberty Operator provides day-2 operations such as `OpenLibertyDump` and `OpenLibertyTrace`
+
+These additional [day-2 operations](https://github.com/OpenLiberty/open-liberty-operator/blob/master/doc/user-guide.md#day-2-operations) make it easier to collect debug data from the running Open Liberty pods in the Kubernetes cluster. 
+
+
 ## Templates
 
 Templates are used to create your local project and start your development. When initializing your project you will be provided with an Open Liberty template application.

--- a/incubator/java-openliberty/image/config/app-deploy.yaml
+++ b/incubator/java-openliberty/image/config/app-deploy.yaml
@@ -1,12 +1,11 @@
-apiVersion: appsody.dev/v1beta1
-kind: AppsodyApplication
+apiVersion: openliberty.io/v1beta1
+kind: OpenLibertyApplication
 metadata:
   name: APPSODY_PROJECT_NAME
 spec:
   # Add fields here
   version: 1.0.0
   applicationImage: APPSODY_DOCKER_IMAGE 
-  stack: APPSODY_STACK
   service:
     type: NodePort
     port: APPSODY_PORT

--- a/incubator/java-openliberty/stack.yaml
+++ b/incubator/java-openliberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Open Liberty
-version: 0.2.3
+version: 0.2.6
 description: Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

Updates the stack to use `OpenLibertyApplication` kind  (Open Liberty Operator)

Tested with `appsody deploy` and `tekton` pipeline.
This will require Open Liberty Operator to be installed before stack is deployed

### Related Issues:
#721 
