### PR TITLE
Update swift stack README.md to remove deprecated flag reference

### DIFF
--- a/incubator/swift/README.md
+++ b/incubator/swift/README.md
@@ -52,7 +52,7 @@ You can enable an existing project as follows:
 2. Initialize your Appsody project with the Swift stack, but without a template:
 
     ```bash
-    appsody init swift --no-template
+    appsody init swift none
     ```
 
 3. After your project has been initialized you can then run your application using the following command:


### PR DESCRIPTION
### Checklist:

- [ ] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ ] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

Removed reference to `--no-template` in the README, as this flag has been deprecated and should now be `none`.

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
