### PR TITLE
starter: bump stack version to put src and image in the index

### DIFF
--- a/incubator/starter/stack.yaml
+++ b/incubator/starter/stack.yaml
@@ -1,5 +1,5 @@
 name: Starter Sample
-version: 0.1.2
+version: 0.1.3
 description: Runnable starter stack, copy to create a new stack
 license: Apache-2.0
 language: bash


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

Due to a bug with the indexes fixed by: https://github.com/appsody/stacks/pull/727 a few stacks lost the `src` and `image` information in the index. Rebumping the version so that this info can be put back in.

cc @henrynash PTAL :)
