### PR TITLE
Language agnostic demo of root-owned dep bug

### DIFF
--- a/incubator/starter/image/Dockerfile-stack
+++ b/incubator/starter/image/Dockerfile-stack
@@ -8,7 +8,7 @@ FROM registry.access.redhat.com/ubi7/ubi
 ENV APPSODY_MOUNTS=/:/project/userapp
 
 # Define a volume for dependencies to be stored between runs, for example
-ENV APPSODY_DEPS=/project/deps
+ENV APPSODY_DEPS=/project/userapp/deps
 
 # Directories to watch for changes in
 ENV APPSODY_WATCH_DIR=/project/userapp
@@ -21,7 +21,7 @@ ENV APPSODY_WATCH_REGEX="^.*.sh$"
 
 # Optional command executed before RUN/TEST/DEBUG - typically used to install any dependencies from
 # the user application
-ENV APPSODY_PREP=
+ENV APPSODY_PREP="ls -l /project /project/userapp /project/userapp/deps; mkdir -p /project/userapp/deps/installed-during-appsody-prep ~/.dep-cache/installed-during-appsody-prep"
 
 # Configurations for appsody run
 # APPSODY_RUN should specify the command to launch your application
@@ -60,3 +60,8 @@ WORKDIR /project
 
 # Expose the relevant ports (change this to be specific to your application).
 EXPOSE 8080
+
+# Run as a non-root user in group 0.
+RUN useradd -u 1001 -r -g 0 -s /usr/sbin/nologin -m default \
+  && chown -R 1001:0 /project
+USER default

--- a/incubator/starter/image/project/Dockerfile
+++ b/incubator/starter/image/project/Dockerfile
@@ -11,3 +11,11 @@ EXPOSE 8080
 
 # Pass control your application
 CMD ["/bin/bash",  "/project/userapp/hello.sh"]
+
+# Run as a non-root user in group 0.
+RUN useradd -u 1001 -r -g 0 -s /usr/sbin/nologin -m default \
+  && chown -R 1001:0 /project
+USER default
+
+# Install deps (deployable equivalent of APPSODY_PREP).
+RUN mkdir -p /project/userapp/deps/installed-during-appsody-build ~/.dep-cache/installed-during-appsody-build

--- a/incubator/starter/templates/simple/hello.sh
+++ b/incubator/starter/templates/simple/hello.sh
@@ -1,1 +1,7 @@
 echo "Hello from Appsody!"
+
+set -e
+set -x
+
+ls -l /project /project/userapp /project/userapp/deps
+mkdir -p created-in-cwd-when-app-runs

--- a/incubator/starter/templates/simple/tests/test.sh
+++ b/incubator/starter/templates/simple/tests/test.sh
@@ -1,1 +1,7 @@
 echo "Running tests for Hello from Appsody!"
+
+set -e
+set -x
+
+ls -l /project /project/userapp /project/userapp/deps
+mkdir -p created-in-cwd-when-app-tests

--- a/incubator/starter/test-appsody-build
+++ b/incubator/starter/test-appsody-build
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+. ./test-common.sh
+
+echo _____________ Do appsody build and ensure it is runnable
+appsody build
+docker run dev.local/ex-$STACK

--- a/incubator/starter/test-appsody-run
+++ b/incubator/starter/test-appsody-run
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+. ./test-common.sh
+
+echo _____________ Do appsody run
+appsody run

--- a/incubator/starter/test-appsody-test
+++ b/incubator/starter/test-appsody-test
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+. ./test-common.sh
+
+echo _____________ Do appsody test
+appsody test

--- a/incubator/starter/test-appsody-test-root-leakage
+++ b/incubator/starter/test-appsody-test-root-leakage
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+. ./test-common.sh
+
+echo _____________ Do appsody test and check host fs is still usable
+appsody test --no-watcher
+mkdir -p deps/installed-on-host-after-test
+rm -rf deps

--- a/incubator/starter/test-common.sh
+++ b/incubator/starter/test-common.sh
@@ -1,0 +1,15 @@
+set -e
+set -x
+
+STACK=$(basename $PWD)
+
+echo _____________ Build stack
+appsody version
+appsody stack package
+
+
+echo _____________ Init from stack
+rm -rf ../ex-$STACK
+mkdir  ../ex-$STACK
+cd     ../ex-$STACK
+appsody init dev.local/$STACK


### PR DESCRIPTION
Issue: https://github.com/appsody/stacks/issues/518

Description: https://github.com/appsody/stacks/issues/518#issuecomment-601957506

This is a minimal, language agnostic, reproduction of issue #518.

Once it works, it might be worth cleaning up and merging as a language
agnostic example of satisfying the non-root user certification
requirement.

To reproduce:
- checkout this PR branch
- cd incubator/starter
- `./test-appsody-test` (fails)
- `./test-appsody-test-root-leakage` (fails)
- `./test-appsody-run` (fails)
- `./test-appsody-build` (passes)
