### PR TITLE
Update app-deploy.yaml

### DIFF
--- a/experimental/java-spring-boot2-liberty/image/config/app-deploy.yaml
+++ b/experimental/java-spring-boot2-liberty/image/config/app-deploy.yaml
@@ -20,6 +20,7 @@ spec:
       port: APPSODY_PORT
     initialDelaySeconds: 5
     periodSeconds: 2
+    timeoutSeconds: 1
   livenessProbe:
     failureThreshold: 12
     httpGet:


### PR DESCRIPTION
Add missing "readinessProbe.timeoutSeconds" value, otherwise we get this error when trying to set "createKnativeService: true" in the stack:

```
status:
  conditions:
  - lastUpdateTime: "2020-04-05T15:26:04Z"
    status: "True"
    type: DependenciesSatisfied
  - lastUpdateTime: "2020-04-05T15:26:04Z"
    message: 'admission webhook "webhook.serving.knative.dev" denied the request:
      validation failed: expected 1 <= 0 <= 2147483647: spec.template.spec.containers[0].readinessProbe.timeoutSeconds'
    reason: BadRequest
    status: "False"
    type: Reconciled
```

cc @BarDweller

### Checklist:

- [ ] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ ] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
