### PR TITLE
Check which stacks are updated or deleted when a stack is being released

### DIFF
--- a/ci/ext/pre_list.d/10_travis
+++ b/ci/ext/pre_list.d/10_travis
@@ -35,30 +35,45 @@ then
         fi
     elif [ $TRAVIS_TAG ]
     then
-        stack_id=`echo ${TRAVIS_TAG/-v[0-9]*/}`
-        echo "Listing stacks for this release"
+    	stack_id=`echo ${TRAVIS_TAG/-v[0-9]*/}`
+    	if [ $TRAVIS_COMMIT ]
+    	then
+            echo "Listing stacks for this commit $TRAVIS_COMMIT"
+            CHANGED_FILES=$(git diff --name-only --no-renames "$TRAVIS_COMMIT~..$TRAVIS_COMMIT" 2>/dev/null)
+            rc=$?
 
-        for repo_name in $REPO_LIST
-        do
-            repo_dir=$base_dir/$repo_name
-            if [ -d $repo_dir ]
+            if [ $rc -eq 0 ]
             then
-                for stack_exists in $repo_dir/*/stack.yaml
+                for changed_stacks in $CHANGED_FILES
                 do
-                    if [ -f $stack_exists ]
+                    if [[ $changed_stacks == *stack.yaml ]]
                     then
-                        var=`echo ${stack_exists#"$base_dir/"}`
-                        repo_stack=`awk '{split($1, a, "/*"); print a[1]"/"a[2]}' <<< $var`
-                        if [[ $repo_stack != */$stack_id ]]
-                        then
-                            continue;
+                        var=`awk '{split($1, a, "/*"); print a[1]"/"a[2]}' <<< $changed_stacks`
+                        # only add stack if it matches the stack id in the TRAVIS_TAG 
+                        if [[ $var == *$stack_id ]]
+                        then 
+                            STACKS_LIST+=("$var")
                         fi
-                        # list of repositories to build indexes for
-                        export STACKS_LIST+=("$repo_stack")
                     fi
                 done
+            else
+                echo "   Unable to identify any changed files in $TRAVIS_COMMIT"
             fi
-        done
+    	fi
+    	
+        if [ -z "${STACKS_LIST}" ]
+        then
+            echo "Listing stacks for this release"
+
+            for repo_name in $REPO_LIST
+            do
+                repo_dir=$base_dir/$repo_name
+                if [ -d $repo_dir ]
+                then
+                	STACKS_LIST+=("$repo_name/$stack_id")
+                fi
+            done
+        fi
 
         if [ -z "${STACKS_LIST}" ]
         then
@@ -95,7 +110,7 @@ then
             printf "  %-50s %-10s %s\n" "$stack_repo/$stack_name" "$stack_version" "$rebuild"
             if [ "$rebuild" = "true" ]
             then
-                export STACKS_LIST+=("$stack_repo/$stack_name")
+                STACKS_LIST+=("$stack_repo/$stack_name")
             fi
         done
     fi
@@ -104,6 +119,13 @@ then
     if [ -z "${STACKS_LIST}" ]
     then
         echo "Choosing a subset of stacks to test with CI/CD changes"
-        export STACKS_LIST="incubator/java-openliberty incubator/java-spring-boot2 incubator/nodejs-express"
+        STACKS_LIST="incubator/java-openliberty incubator/java-spring-boot2 incubator/nodejs-express"
     fi
+    
+    if [ $STACKS_LIST ]
+    then
+       	export STACKS_LIST=${STACKS_LIST[@]}
+    fi
+        
+    echo "STACKS_LIST = '$STACKS_LIST'"
 fi

--- a/ci/package.sh
+++ b/ci/package.sh
@@ -29,12 +29,11 @@ do
         # iterate over each stack
         for stack in $(ls $repo_dir/*/stack.yaml 2>/dev/null | sort)
         do
-            echo $stack
             stack_dir=$(dirname $stack)
 
             if [ -d $stack_dir ]
             then
-                pushd $stack_dir
+                pushd $stack_dir &>/dev/null
 
                 stack_id=$(basename $stack_dir)
                 stack_version=$(awk '/^version *:/ { gsub("version:","",$NF); gsub("\"","",$NF); print $NF}' $stack)
@@ -138,7 +137,7 @@ do
                     echo -e "\n- SKIPPING stack image: $repo_name/$stack_id"
                 fi
 
-                popd
+                popd &>/dev/null
             fi
         done
 


### PR DESCRIPTION
Signed-off-by: Steven Groeger <groeges@uk.ibm.com>

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->
Currently, on a stack release the stack will be being built is determined from the TRAVIS_TAG.
When using the TRAVIS_TAG, If a stack is moved or deleted  that stack is not added to the list to be built. This causes issues as a deleted / removed stack will not be removed from the index file.

This PR changes the way   the stacks to be built are checked. When a release. build is being performed the commit that is associated with the TRAVIS_TAG is checked to see which stacks in the commit match the stack name in the TRAVIS_TAG. If this check doesn't find any matching stacks then the stack named in the TRAVIS_TAG is added to the built list for each repo that is configured. 

This latter check will aways add the stack for each repo, but this will not cause issues if the stack doesn't exist in the repo as it will just try and remove it.  

This PR also removes some unwanted log output from package.sh

### Contributing a new stack:


- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
