### PR TITLE
java-microprofile: deprecate stack

### DIFF
--- a/incubator/java-microprofile/README.md
+++ b/incubator/java-microprofile/README.md
@@ -1,4 +1,6 @@
-# Java MicroProfile Stack
+# Java MicroProfile Stack (DEPRECATED)
+
+## This stack has been deprecated! Please use the [Java Open Liberty](https://github.com/appsody/stacks/tree/master/incubator/java-openliberty) stack.
 
 The Java MicroProfile stack provides a consistent way of developing microservices based upon the [Eclipse MicroProfile specifications](https://microprofile.io). This stack lets you use [Maven](https://maven.apache.org) to develop applications for [Open Liberty](https://openliberty.io) runtime, that is running on OpenJDK with container-optimizations in OpenJ9.
 

--- a/incubator/java-microprofile/README.md
+++ b/incubator/java-microprofile/README.md
@@ -44,6 +44,13 @@ OpenAPI endpoints:
 - http://localhost:9080/openapi (the RESTful APIs of the inventory service)
 - http://localhost:9080/openapi/ui (Swagger UI of the deployed APIs)
 
+### Config dropin: **quick-start-security.xml**
+
+The metrics endpoint is secured with a userid and password enabled through the config dropin included in the default template at path:
+**src/main/liberty/config/configDropins/defaults/quick-start-security.xml**.
+
+In order to lock down the production image built via `appsody build` this file is deleted during the Docker build of your application production image.  (The same file would be deleted if you happened to create your own file at this location as well).
+
 ## Getting Started
 
 1. Create a new folder in your local directory and initialize it using the Appsody CLI, e.g.:
@@ -73,6 +80,8 @@ OpenAPI endpoints:
     - OpenAPI endpoint: http://localhost:9080/openapi
     - Swagger UI endpoint: http://localhost:9080/openapi/ui
     - Javametrics Dashboard endpoint: http://localhost:9080/javametrics-dash/ (development-time only)
+
+
 
 ## License
 

--- a/incubator/java-microprofile/image/project/Dockerfile
+++ b/incubator/java-microprofile/image/project/Dockerfile
@@ -23,6 +23,7 @@ RUN cd /project/user-app && mvn -B liberty:install-server
 # Remove quick-start-security.xml since it is only needed during local development.
 COPY ./user-app/src /project/user-app/src
 RUN cd /project/user-app && \
+    echo "QUICK START SECURITY IS NOT SECURE FOR PRODUCTION ENVIRONMENTS. IT IS BEING REMOVED" \
     rm -f src/main/liberty/config/configDropins/defaults/quick-start-security.xml && \
     mvn package -DskipTests
 

--- a/incubator/java-microprofile/stack.yaml
+++ b/incubator/java-microprofile/stack.yaml
@@ -1,5 +1,5 @@
 name: Eclipse MicroProfile®
-version: 0.2.24
+version: 0.2.25
 description: Eclipse MicroProfile on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java

--- a/incubator/java-microprofile/stack.yaml
+++ b/incubator/java-microprofile/stack.yaml
@@ -1,6 +1,6 @@
 name: Eclipse MicroProfile®
 version: 0.2.26
-description: This stack has been deprecated. Please use the Open Liberty stack. 
+description: Eclipse MicroProfile on Open Liberty & OpenJ9 using Maven 
 license: Apache-2.0
 language: java
 maintainers:
@@ -21,4 +21,4 @@ requirements:
     appsody-version: ">= 0.5.0"
 templating-data:
     libertyversion: '19.0.0.12'
-deprecated: 04/20/2020 - Replaced with the Open Liberty stack (java-openliberty).
+deprecated: 04/20/2020 - This stack has been replaced by the Open Liberty stack (java-openliberty)

--- a/incubator/java-microprofile/stack.yaml
+++ b/incubator/java-microprofile/stack.yaml
@@ -1,6 +1,6 @@
 name: Eclipse MicroProfile®
-version: 0.2.25
-description: Eclipse MicroProfile on Open Liberty & OpenJ9 using Maven
+version: 0.2.26
+description: This stack has been deprecated. Please use the Open Liberty stack. 
 license: Apache-2.0
 language: java
 maintainers:
@@ -18,3 +18,4 @@ requirements:
     appsody-version: ">= 0.5.0"
 templating-data:
     libertyversion: '19.0.0.12'
+deprecated: 04/14/2020 - Please use the Open Liberty stack as a replacement. 


### PR DESCRIPTION
### Checklist:

- [x ] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [ x] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

Deprecate the Java Microprofile Stack
- Update stack description to show deprecation
- Mark stack as deprecated in stack.yaml
- Indicate deprecation in Readme

### Related Issues:
Fixes #751 
