### PR TITLE
quarkus: add smallrye-metrics

### DIFF
--- a/incubator/quarkus/image/project/pom.xml
+++ b/incubator/quarkus/image/project/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>dev.appsody</groupId>
     <artifactId>quarkus</artifactId>
-    <version>0.3.3</version>
+    <version>0.3.4</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/incubator/quarkus/stack.yaml
+++ b/incubator/quarkus/stack.yaml
@@ -1,5 +1,5 @@
 name: Quarkus
-version: 0.3.3
+version: 0.3.4
 description: Quarkus runtime for running Java applications
 license: Apache-2.0
 language: java

--- a/incubator/quarkus/templates/default/pom.xml
+++ b/incubator/quarkus/templates/default/pom.xml
@@ -15,6 +15,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
         <dependency>

--- a/incubator/quarkus/templates/kafka/pom.xml
+++ b/incubator/quarkus/templates/kafka/pom.xml
@@ -15,6 +15,10 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
The Quarkus stack does not include any metrics by default.

This PR adds the `quarkus-smallrye-metrics` dependency to `pom.xml` so that a basic set of metrics are automatically generated and hosted on `/metrics`.

The purpose of this is so that the default app is "Kubernetes ready" - in particular, so that the monitoring features in the Appsody Operator work: https://github.com/application-stacks/runtime-component-operator/blob/master/doc/user-guide.md#Monitoring