### PR TITLE
Update to add deprecated flag to codewind index json file

### DIFF
--- a/ci/create_codewind_index.py
+++ b/ci/create_codewind_index.py
@@ -34,7 +34,7 @@ def generate_json():
                                 template = ""
                             else:
                                 template = " " + item['templates'][n]['id']
-
+                            
                             # populate stack details
                             res = (OrderedDict([
                                 ("displayName", displayNamePrefix + " " + item['name'] + template + " template"),
@@ -48,6 +48,11 @@ def generate_json():
                                         item['id'] + "/devfile.yaml")
                                 ]))
                             ]))
+                            
+                            if ('deprecated' in item):
+                                res.update([("displayName", "[Deprecated] " + displayNamePrefix + " " + item['name'] + template + " template"),
+                                             ("deprecated", item['deprecated'])])
+                                
                             list.append(res)
 
                 jsonFile.write(json.dumps(list, indent=4, ensure_ascii=False).encode('utf8'))


### PR DESCRIPTION
Signed-off-by: Steven Groeger <groeges@uk.ibm.com>

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->
If the index.yaml file has a `deprecated` element for a stack the generated codewind index json file need to have a similar element. This change adds the `deprecated` element to the json file.
 
### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
