### PR TITLE
nodejs-express: use pino-http directly

### DIFF
--- a/incubator/nodejs-express/README.md
+++ b/incubator/nodejs-express/README.md
@@ -59,7 +59,7 @@ Options contains:
   to the server. For example, with [socket.io](https://socket.io/):
   `io = require('socket.io')(options.server)`.
 
-The [`express-pino-logger`](https://registry.npmjs.org/express-pino-logger) has been registered as middleware, so:
+The [`pino-http`](https://registry.npmjs.org/pino-http) has been registered as middleware, so:
 1. All requests will be logged as JSON, for easy consumability by log aggregators.
 2. All `req` objects will be decorated with a `req.log` property, an instance of [`pino`](https://registry.npmjs.org/pino). It can be used for application specific logging. The default log level is `'info'` in production, and `'debug'` in non-production.
 

--- a/incubator/nodejs-express/image/project/package-lock.json
+++ b/incubator/nodejs-express/image/project/package-lock.json
@@ -874,14 +874,6 @@
         "vary": "~1.1.2"
       }
     },
-    "express-pino-logger": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/express-pino-logger/-/express-pino-logger-4.0.0.tgz",
-      "integrity": "sha512-BTJwjQXMSR6tFiyvTOOr6aosJkJOuJpW0mXE+icv3ae/0WXBGnLaumINGHJvWMuDO1RSLHBLfRrJaghMjMhVrg==",
-      "requires": {
-        "pino-http": "^4.0.0"
-      }
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1990,25 +1982,25 @@
       "dev": true
     },
     "pino": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
-      "integrity": "sha512-LqrqmRcJz8etUjyV0ddqB6OTUutCgQULPFg2b4dtijRHUsucaAdBgSUW58vY6RFSX+NT8963F+q0tM6lNwGShA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.2.0.tgz",
+      "integrity": "sha512-UzrsiT5Wyscw7dxHa8Ec8G2kY45mwFk7rrZhMkCMg8s9F8VWDVj+WFcaSIKproTDyxlqerMaHw+11jlNXgeiCg==",
       "requires": {
         "fast-redact": "^2.0.0",
         "fast-safe-stringify": "^2.0.7",
         "flatstr": "^1.0.12",
         "pino-std-serializers": "^2.4.2",
-        "quick-format-unescaped": "^3.0.3",
-        "sonic-boom": "^0.7.5"
+        "quick-format-unescaped": "^4.0.1",
+        "sonic-boom": "^1.0.0"
       }
     },
     "pino-http": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-4.5.0.tgz",
-      "integrity": "sha512-Z9u1KS+6JQ0v5erreYYo8MWIU/FtjkPYFZzLgBUZ+qTlp0Hdq89SXujOXfSHVySLLS0Uk8fD41/TrFhmvhxCFg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-5.0.0.tgz",
+      "integrity": "sha512-1D64WYIS6j1GouDrI3a3n60GGV8Fvp4sXIeYAD+atg/qneZxmzOlWpQoDphgjeeEEIRUG0JMol0bJ5vMU3Zk5Q==",
       "requires": {
         "fast-url-parser": "^1.1.3",
-        "pino": "^5.0.0",
+        "pino": "^6.0.0",
         "pino-std-serializers": "^2.4.0"
       }
     },
@@ -2072,9 +2064,9 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "quick-format-unescaped": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
-      "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
+      "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A=="
     },
     "range-parser": {
       "version": "1.2.1",
@@ -2407,9 +2399,9 @@
       }
     },
     "sonic-boom": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.7.tgz",
-      "integrity": "sha512-Ei5YOo5J64GKClHIL/5evJPgASXFVpfVYbJV9PILZQytTK6/LCwHvsZJW2Ig4p9FMC2OrBrMnXKgRN/OEoAWfg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.0.1.tgz",
+      "integrity": "sha512-o9tx+bonVEXSaPtptyXQXpP8l6UV9Bi3im2geZskvWw2a/o/hrbWI7EBbbv+rOx6Hubnzun9GgH4WfbgEA3MFQ==",
       "requires": {
         "atomic-sleep": "^1.0.0",
         "flatstr": "^1.0.12"

--- a/incubator/nodejs-express/image/project/package.json
+++ b/incubator/nodejs-express/image/project/package.json
@@ -16,9 +16,9 @@
   "dependencies": {
     "@cloudnative/health-connect": "^2.0.0",
     "express": "^4.17.1",
-    "express-pino-logger": "^4.0.0",
     "node-rdkafka": "^2.7.4",
-    "pino": "^5.14.0",
+    "pino": "^6.2.0",
+    "pino-http": "^5.0.0",
     "prom-client": "^12.0.0"
   },
   "devDependencies": {

--- a/incubator/nodejs-express/image/project/server.js
+++ b/incubator/nodejs-express/image/project/server.js
@@ -54,7 +54,7 @@ app.use(requestTimer);
 const pino = require('pino')({
   level: PRODUCTION ? 'info' : 'debug',
 });
-app.use(require('express-pino-logger')({logger: pino}));
+app.use(require('pino-http')({logger: pino}));
 
 // Register the user's app.
 const basePath = __dirname + '/user-app/';

--- a/incubator/nodejs-express/stack.yaml
+++ b/incubator/nodejs-express/stack.yaml
@@ -1,5 +1,5 @@
 name: Node.js Express
-version: 0.4.8
+version: 0.4.9
 description: Express web framework for Node.js
 license: Apache-2.0
 language: nodejs


### PR DESCRIPTION
It turns out that express-pino-logger just returns pino-http, so use it
directly, as is the current recommendations.

See:
- https://github.com/pinojs/pino/commit/3acca206f6cfa70fa20c6b1e7eee1311910ad671
- https://github.com/pinojs/express-pino-logger/blob/2b9bd6a551610a4ba4a6c0e42de94b3fe7804298/logger.js#L2

### Checklist:

- [ ] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ ] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
