### PR TITLE
Temporarily remove java-openliberty from default stacks list

### DIFF
--- a/ci/ext/pre_list.d/10_travis
+++ b/ci/ext/pre_list.d/10_travis
@@ -119,7 +119,7 @@ then
     if [ -z "${STACKS_LIST}" ]
     then
         echo "Choosing a subset of stacks to test with CI/CD changes"
-        STACKS_LIST="incubator/java-openliberty incubator/java-spring-boot2 incubator/nodejs-express"
+        STACKS_LIST="incubator/java-spring-boot2 incubator/nodejs-express"
     fi
     
     if [ $STACKS_LIST ]


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

Temporarily removes the `java-openliberty` stack from the default stacks list until problems reported in https://github.com/appsody/stacks/issues/799 are resolved.
