### PR TITLE
java-openliberty: fix stack validate

### DIFF
--- a/incubator/java-openliberty/stack.yaml
+++ b/incubator/java-openliberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Open Liberty
-version: 0.2.11
+version: 0.2.12
 description: Eclipse MicroProfile & Jakarta EE on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java

--- a/incubator/java-openliberty/templates/kafka/README.md
+++ b/incubator/java-openliberty/templates/kafka/README.md
@@ -25,15 +25,13 @@ Start docker compose with the following command:
 
 If you run `docker network list`, you should see a new network with the name of your project directory and the word `_default` appended. For example, `test-appsody-kafka_default`.
 
-Alternatively, if you want to connect to a Kafka broker elsewhere, edit `src/main/resources/META-INF/microprofile-config.properties` and set the value of the `mp.messaging.connector.liberty-kafka.bootstrap.servers` property to the host and port number of the your broker.
-
 ### 3. Run the Appsody application in the new network
 
-Your Appsody application must be run in the same network as Kafka.
+Your Appsody application must be run in the same network as Kafka. You must also supply the host and port number of the Kakfka broker as an environment variable. 
 
 Run the application using the following command:
 
-```appsody run --network test-appsody-kafka_default```
+```appsody run --network test-appsody-kafka_default --docker-options "-e MP_MESSAGING_CONNECTOR_LIBERTY_KAFKA_BOOTSTRAP_SERVERS=kafka:9092"```
 
 ### 4. Produce a message to a topic
 

--- a/incubator/java-openliberty/templates/kafka/README.md
+++ b/incubator/java-openliberty/templates/kafka/README.md
@@ -33,6 +33,14 @@ Run the application using the following command:
 
 ```appsody run --network test-appsody-kafka_default --docker-options "--env MP_MESSAGING_CONNECTOR_LIBERTY_KAFKA_BOOTSTRAP_SERVERS=kafka:9092"```
 
+Alternatively, edit `src/main/resources/META-INF/microprofile-config.properties` as follows:
+
+```
+mp.messaging.connector.liberty-kafka.bootstrap.servers=kafka:9092
+```
+
+(this value is provided in the sample file, commented out)
+
 ### 4. Produce a message to a topic
 
 Run another container in the same network:

--- a/incubator/java-openliberty/templates/kafka/README.md
+++ b/incubator/java-openliberty/templates/kafka/README.md
@@ -27,11 +27,11 @@ If you run `docker network list`, you should see a new network with the name of 
 
 ### 3. Run the Appsody application in the new network
 
-Your Appsody application must be run in the same network as Kafka. You must also supply the host and port number of the Kakfka broker as an environment variable. 
+Your Appsody application must be run in the same network as Kafka. You must also supply the host and port number of the Kafka broker as an environment variable. 
 
 Run the application using the following command:
 
-```appsody run --network test-appsody-kafka_default --docker-options "-e MP_MESSAGING_CONNECTOR_LIBERTY_KAFKA_BOOTSTRAP_SERVERS=kafka:9092"```
+```appsody run --network test-appsody-kafka_default --docker-options "--env MP_MESSAGING_CONNECTOR_LIBERTY_KAFKA_BOOTSTRAP_SERVERS=kafka:9092"```
 
 ### 4. Produce a message to a topic
 

--- a/incubator/java-openliberty/templates/kafka/pom.xml
+++ b/incubator/java-openliberty/templates/kafka/pom.xml
@@ -190,30 +190,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>appsody-build</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-        </profile>
-        <profile>
-            <id>local-dev</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-        </profile>
-        <profile>
-            <id>default-profile</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <liberty.var.mp.messaging.connector.liberty-kafka.bootstrap.servers>localhost:9093</liberty.var.mp.messaging.connector.liberty-kafka.bootstrap.servers>
-            </properties>
-        </profile>
-    </profiles>
- 
-     
 </project>

--- a/incubator/java-openliberty/templates/kafka/src/main/resources/META-INF/microprofile-config.properties
+++ b/incubator/java-openliberty/templates/kafka/src/main/resources/META-INF/microprofile-config.properties
@@ -1,4 +1,5 @@
 mp.messaging.connector.liberty-kafka.bootstrap.servers=localhost:9093
+## mp.messaging.connector.liberty-kafka.bootstrap.servers=kafka:9092
 
 ## incomingTopic1 topic
 mp.messaging.incoming.incomingTopic1.connector=liberty-kafka

--- a/incubator/java-openliberty/templates/kafka/src/main/resources/META-INF/microprofile-config.properties
+++ b/incubator/java-openliberty/templates/kafka/src/main/resources/META-INF/microprofile-config.properties
@@ -1,10 +1,8 @@
-mp.messaging.connector.liberty-kafka.bootstrap.servers=kafka:9092
+mp.messaging.connector.liberty-kafka.bootstrap.servers=localhost:9093
 
 ## incomingTopic1 topic
 mp.messaging.incoming.incomingTopic1.connector=liberty-kafka
 mp.messaging.incoming.incomingTopic1.topic=incomingTopic1
-mp.messaging.incoming.incomingTopic1.value.serializer=org.apache.kafka.common.serialization.StringSerializer
-mp.messaging.incoming.incomingTopic1.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.incoming.incomingTopic1.group.id=starter
 
 ## outgoingTopic1 topic
@@ -15,6 +13,4 @@ mp.messaging.outgoing.outgoingTopic1.key.serializer=org.apache.kafka.common.seri
 ## incomingTopic2 topic
 mp.messaging.incoming.incomingTopic2.connector=liberty-kafka
 mp.messaging.incoming.incomingTopic2.topic=incomingTopic2
-mp.messaging.incoming.incomingTopic2.value.serializer=org.apache.kafka.common.serialization.StringSerializer
-mp.messaging.incoming.incomingTopic2.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.incoming.incomingTopic2.group.id=starter


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

Fix `appsody stack validate` for java-openliberty kafka template.
`appsody test` was failing because the Liberty application did not start. This was because the kafka host specified in `microprofile-config.properties` was `kafka`, the correct hostname for use with the supplied `docker-compose.yaml`.  However, when running `stack validate`, the Docker compose environment wasn't there and therefore the host could not be resolved. 
To fix this I've set the default host for Kafka in `microprofile-config.properties` to be `localhost`.  This allows the Liberty app to start (even though it still won't connect to a Kafka) and therefore `appsody test` will pass during `stack validate`. 
This also means the default configuration is correct for host-mode develepment (`mvn liberty:dev`) so I've removed the profile overrides from `pom.xml`.
I've updated the README, telling the user to set the environment variable to override the Kafka boostrap server when using the Docker compose environment.

I also spotted some unneeded properties in the config file that were causing warning messages.


### Related Issues:
Fixes #799 
