### PR TITLE
quarkus: add monitoring to app-deploy.yaml

### DIFF
--- a/incubator/quarkus/image/config/app-deploy.yaml
+++ b/incubator/quarkus/image/config/app-deploy.yaml
@@ -10,4 +10,7 @@ spec:
   service:
     type: NodePort
     port: APPSODY_PORT
+  monitoring:
+    labels:
+      k8s-app: APPSODY_PROJECT_NAME
   expose: true

--- a/incubator/quarkus/image/project/pom.xml
+++ b/incubator/quarkus/image/project/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>dev.appsody</groupId>
     <artifactId>quarkus</artifactId>
-    <version>0.3.5</version>
+    <version>0.3.6</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/incubator/quarkus/stack.yaml
+++ b/incubator/quarkus/stack.yaml
@@ -1,5 +1,5 @@
 name: Quarkus
-version: 0.3.5
+version: 0.3.6
 description: Quarkus runtime for running Java applications
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

Add the `monitoring` section to `app-deploy.yaml`. This means that the Appsody Operator will autocreate a `ServiceMonitor` CR for consumption into Prometheus.