### PR TITLE
java-openliberty: Work around docker bug

### DIFF
--- a/incubator/java-openliberty/image/project/Dockerfile
+++ b/incubator/java-openliberty/image/project/Dockerfile
@@ -64,6 +64,9 @@ FROM openliberty/open-liberty:{{.stack.libertyversion}}-kernel-java8-openj9-ubi
 #2a) copy any resources 
 COPY --chown=1001:0 --from=compile /shared /opt/ol/wlp/usr/shared/
 
+# Work around https://github.com/moby/moby/issues/37965
+RUN true
+
 # 2b) next copy shared library
 #      but can't assume config/lib exists - copy from previous stage to a tmp holding place and test
 COPY --chown=1001:0 --from=compile /configlibdir/ /config

--- a/incubator/java-openliberty/image/project/Dockerfile
+++ b/incubator/java-openliberty/image/project/Dockerfile
@@ -64,7 +64,7 @@ FROM openliberty/open-liberty:{{.stack.libertyversion}}-kernel-java8-openj9-ubi
 #2a) copy any resources 
 COPY --chown=1001:0 --from=compile /shared /opt/ol/wlp/usr/shared/
 
-# Work around https://github.com/moby/moby/issues/37965
+# Work around https://github.com/moby/moby/issues/37965.  It seems the problem may be triggered when the previous COPY command adds no contents to the layer it is building (because it was empty). 
 RUN true
 
 # 2b) next copy shared library

--- a/incubator/java-openliberty/stack.yaml
+++ b/incubator/java-openliberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Open Liberty
-version: 0.2.12
+version: 0.2.13
 description: Eclipse MicroProfile & Jakarta EE on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

When trying to do an `appsody build` using the java-openliberty stack in a GitHub Actions, CI environment, I hit the following error: 
```
[Docker] Step 18/68 : COPY --chown=1001:0 --from=compile /configlibdir/ /config
[Docker] failed to export image: failed to create image: failed to get layer sha256:27f55a0113aeec813a6bb31695fd2449c4dc13fe53adb7a67e144c325b63bdf7: layer does not exist
[Error] exit status 1
```
This appears to be caused by moby/moby#37965.  The characteristics of the `COPY` don't exactly match the description in the issue but the symptom is the same.    This issue has been open for a while and there's no sign of a fix so I think it's worth putting a workaround in the stack. I've added the suggested `RUN true`, which fixes the issue for me.  It seems like subsequent `COPY` commands could hit the same issue, but in practice they don't for me, so I've just put in the one instance for now.



