### PR TITLE
nodejs-express: Shut down Kafka clients when HTTP server is closed

### DIFF
--- a/incubator/nodejs-express/stack.yaml
+++ b/incubator/nodejs-express/stack.yaml
@@ -1,5 +1,5 @@
 name: Node.js Express
-version: 0.4.10
+version: 0.4.11
 description: Express web framework for Node.js
 license: Apache-2.0
 language: nodejs

--- a/incubator/nodejs-express/stack.yaml
+++ b/incubator/nodejs-express/stack.yaml
@@ -1,5 +1,5 @@
 name: Node.js Express
-version: 0.4.11
+version: 0.4.12
 description: Express web framework for Node.js
 license: Apache-2.0
 language: nodejs

--- a/incubator/nodejs-express/templates/kafka/app.js
+++ b/incubator/nodejs-express/templates/kafka/app.js
@@ -31,8 +31,15 @@ module.exports = (options) => {
     // 'log.connection.close' : false,
   }
 
-  Produce(Kafka, config, log, app);
-  Consume(Kafka, brokers, log);
+  producer = Produce(Kafka, config, log, app);
+  consumer = Consume(Kafka, brokers, log);
+
+  // Disconnect our Kafka clients when the HTTP server is stopped.
+  options.server.on('close', function () {
+    log.info('Disconnecting Kafka clients');
+    producer.disconnect();
+    consumer.disconnect();
+  });
 
   return app;
 };
@@ -89,6 +96,7 @@ function Produce(Kafka, config, log, app) {
 
   // starting the producer
   producer.connect();
+  return producer;
 }
 
 // Based on:
@@ -145,4 +153,5 @@ function Consume(Kafka, brokers, log) {
 
   // starting the consumer
   consumer.connect();
+  return consumer;
 }


### PR DESCRIPTION
This PR illustrates how to avoid a hang when running the stack tests where the application makes connections to external services.

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->
I have added a callback on the HTTP server `close` event, to disconnect the Kafka producer and consumer.  This allows the process to terminate normally.

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->

Resolves #831