### PR TITLE
python-flask: Avoid permission errors when building dependencies

### DIFF
--- a/incubator/python-flask/image/Dockerfile-stack
+++ b/incubator/python-flask/image/Dockerfile-stack
@@ -20,7 +20,7 @@ ENV APPSODY_USER_RUN_AS_LOCAL=false
 ENV APPSODY_WATCH_DIR=/project/userapp
 ENV APPSODY_WATCH_REGEX="^.*.py$"
 
-ENV APPSODY_PREP="cd /project/userapp;pipenv lock -r > requirements.txt;python -m pip install -r requirements.txt -t /project/deps"
+ENV APPSODY_PREP="cd /project/userapp;whoami;ls -al;pipenv lock -r > requirements.txt;python -m pip install -r requirements.txt -t /project/deps"
 
 ENV APPSODY_RUN="python -m flask run --host=0.0.0.0 --port=8080"
 ENV APPSODY_RUN_ON_CHANGE=$APPSODY_RUN

--- a/incubator/python-flask/image/Dockerfile-stack
+++ b/incubator/python-flask/image/Dockerfile-stack
@@ -13,7 +13,9 @@ ENV PATH=/home/worker/.local/bin:$PATH
 
 ENV APPSODY_MOUNTS=/:/project/userapp
 ENV APPSODY_DEPS=/project/deps
-ENV APPSODY_USER_RUN_AS_LOCAL=true
+# This (and the project) Dockerfile already ensure we run as worker, rather than root - so don't enable running as the local
+# user, since this would casue a clash of two different UIDs
+ENV APPSODY_USER_RUN_AS_LOCAL=false
 
 ENV APPSODY_WATCH_DIR=/project/userapp
 ENV APPSODY_WATCH_REGEX="^.*.py$"

--- a/incubator/python-flask/image/Dockerfile-stack
+++ b/incubator/python-flask/image/Dockerfile-stack
@@ -14,7 +14,7 @@ ENV PATH=/home/worker/.local/bin:$PATH
 ENV APPSODY_MOUNTS=/:/project/userapp
 ENV APPSODY_DEPS=/project/deps
 # This (and the project) Dockerfile already ensure we run as worker, rather than root - so don't enable running as the local
-# user, since this would casue a clash of two different UIDs
+# user, since this would cause a clash of two different UIDs
 ENV APPSODY_USER_RUN_AS_LOCAL=false
 
 ENV APPSODY_WATCH_DIR=/project/userapp

--- a/incubator/python-flask/image/Dockerfile-stack
+++ b/incubator/python-flask/image/Dockerfile-stack
@@ -20,7 +20,7 @@ ENV APPSODY_USER_RUN_AS_LOCAL=false
 ENV APPSODY_WATCH_DIR=/project/userapp
 ENV APPSODY_WATCH_REGEX="^.*.py$"
 
-ENV APPSODY_PREP="cd /project/userapp;whoami;ls -al;pipenv lock -r > requirements.txt;python -m pip install -r requirements.txt -t /project/deps"
+ENV APPSODY_PREP="cd /project/userapp;pipenv lock -r > ../requirements-additional.txt;python -m pip install -r ../requirements-additional.txt -t /project/deps"
 
 ENV APPSODY_RUN="python -m flask run --host=0.0.0.0 --port=8080"
 ENV APPSODY_RUN_ON_CHANGE=$APPSODY_RUN

--- a/incubator/python-flask/image/project/Dockerfile
+++ b/incubator/python-flask/image/project/Dockerfile
@@ -3,23 +3,27 @@ FROM python:3.7
 RUN pip install --upgrade pip
 
 RUN useradd -m worker
-USER worker
 WORKDIR /project
+# It is a real shame that WORKDIR doesn't honor the current user (or even take a chown option), so.....
+RUN chown worker:worker /project
+USER worker
 
 RUN pip install --upgrade --user pipenv
 ENV PATH=/home/worker/.local/bin:$PATH
 
 COPY --chown=worker:worker . ./
+
 # First we get the dependencies for the stack itself
 RUN pipenv lock -r > requirements.txt
 # Now add in any for the app, that the developer has added (there seems to be
 # no easy way of specifying a different location for the Pipfile, so have to 
 # change the working directory!)
 WORKDIR /project/userapp
-RUN pipenv lock -r > ../requirements.txt
+RUN pipenv lock -r > ../requirements-additional.txt
 # Now process the combined requirements
 WORKDIR /project
 RUN python -m pip install -r requirements.txt -t /project/deps
+RUN python -m pip install -r requirements-additional.txt -t /project/deps
 
 ENV PYTHONPATH=/project/deps
 ENV FLASK_APP=server/__init__.py

--- a/incubator/python-flask/stack.yaml
+++ b/incubator/python-flask/stack.yaml
@@ -1,5 +1,5 @@
 name: Python Flask
-version: 0.2.3
+version: 0.2.4
 description: Flask web Framework for Python
 language: python
 maintainers:


### PR DESCRIPTION
Avoid clashing UIDs in the attempt to ensure the application does not run as root. Since the Dockerfiles already create a non-root user, do not also set APPSODY_USER_RUN_AS_LOCAL to true.

Attempting to only use APPSODY_USER_RUN_AS_LOCAL=true and not create a user in the Dockerfile, leads to different issues regarding clashing UIDs

Fixes #833 
