### PR TITLE
rust-tide: Next tide and rust runtime releases

### DIFF
--- a/experimental/rust-tide/README.md
+++ b/experimental/rust-tide/README.md
@@ -4,7 +4,7 @@ The Rust Tide stack provides a consistent way of developing [tide](https://githu
 
 Designed to be used with [Appsody](https://appsody.dev/) an [open source](https://github.com/appsody/) development and operations accelerator for containers.
 
-This stack is based on the `Rust 1.43.1` runtime.
+This stack is based on the `Rust 1.44.0-buster` runtime release.
 
 ## Templates
 

--- a/experimental/rust-tide/image/Dockerfile-stack
+++ b/experimental/rust-tide/image/Dockerfile-stack
@@ -1,4 +1,4 @@
-FROM rust:1.43.1-buster
+FROM rust:1.44.0-buster
 
 RUN apt-get update && apt-get install -y gdbserver 
 
@@ -17,6 +17,7 @@ ENV APPSODY_RUN_KILL=true
 ENV APPSODY_DEBUG="cargo build --manifest-path ../server/bin/Cargo.toml && gdbserver localhost:1234 /project/server/bin/target/debug/rust-tide-server"
 ENV APPSODY_DEBUG_ON_CHANGE="$APPSODY_DEBUG"
 ENV APPSODY_DEBUG_KILL=true
+ENV APPSODY_DEBUG_PORT=1234
 
 ENV APPSODY_TEST="/project/test-stack.sh"
 ENV APPSODY_TEST_ON_CHANGE=$APPSODY_TEST
@@ -33,4 +34,3 @@ ENV PORT=8000
 
 EXPOSE 8000
 EXPOSE 1234
-EXPOSE 5000

--- a/experimental/rust-tide/image/project/Dockerfile
+++ b/experimental/rust-tide/image/project/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/number9/rust-tide-base:0.2.0 as server
+FROM docker.io/number9/rust-tide-base:0.3.0 as server
 
-FROM rust:1.43.1-buster as builder
+FROM rust:1.44.0-buster as builder
 
 COPY --from=server /project/server /project/server
 

--- a/experimental/rust-tide/image/project/server/bin/Cargo.toml
+++ b/experimental/rust-tide/image/project/server/bin/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tide = { version = "0.10" }
+tide = { version = "0.11" }
 async-std = { version = "1" }
 application = { package = "rust-tide-default", path = "/project/user-app"}

--- a/experimental/rust-tide/image/project/server/bin/Dockerfile
+++ b/experimental/rust-tide/image/project/server/bin/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.43.1-buster
+FROM rust:1.44.0-buster
 # This file is used to publish the server as a base image.
 # docker build -t docker.io/number9/rust-tide-base:v1.0.0 .
 # docker push docker.io/number9/rust-tide-base:v1.0.0 .

--- a/experimental/rust-tide/stack.yaml
+++ b/experimental/rust-tide/stack.yaml
@@ -1,5 +1,5 @@
 name: Rust Tide
-version: 0.2.0
+version: 0.3.0
 description: Tide web framework for Rust
 license: Apache-2.0
 language: rust

--- a/experimental/rust-tide/templates/default/Cargo.toml
+++ b/experimental/rust-tide/templates/default/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tide = { version = "0.10" }
+tide = { version = "0.11" }
 http-types = "2.0.1"
 async-std = { version = "1" }
 surf = { version = "2.0.0-alpha.3", default-features = false, features = ["h1-client"] }

--- a/experimental/rust-tide/templates/default/src/lib.rs
+++ b/experimental/rust-tide/templates/default/src/lib.rs
@@ -1,5 +1,5 @@
 pub fn app() -> tide::Server<()> {    
     let mut api = tide::new();
-    api.at("/").get(|_| async move { Ok("Hello, world!") });
+    api.at("/").get(|_| async { Ok("Hello, world!") });
     api
 }


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

Updates for the stack to keep in sync with upstream releases

tide has released 0.11
https://github.com/http-rs/tide/releases/tag/v0.11.0 

rust has released 1.44.0
https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1440-2020-06-04 

