### PR TITLE
nodejs-express: Install ca-certificates when building production image

### DIFF
--- a/incubator/nodejs-express/image/project/Dockerfile
+++ b/incubator/nodejs-express/image/project/Dockerfile
@@ -26,7 +26,7 @@ RUN cd / && tar czf project.tgz project
 FROM node:12-slim
 
 # librdkafka links against libssl
-RUN apt-get update && apt-get install -y libssl1.1 && apt-get clean
+RUN apt-get update && apt-get install -y libssl1.1 ca-certificates && apt-get clean
 
 # Copy project with dependencies
 COPY --chown=node:node --from=0 /project.tgz /

--- a/incubator/nodejs-express/stack.yaml
+++ b/incubator/nodejs-express/stack.yaml
@@ -1,5 +1,5 @@
 name: Node.js Express
-version: 0.4.12
+version: 0.4.13
 description: Express web framework for Node.js
 license: Apache-2.0
 language: nodejs


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

Installs the `ca-certificates` package when building the production image for an application based on the nodejs-express stack.  This is necessary because the base `node:12-slim` image does not include that package, and it is required in order for TLS certificate validation to work for any properly signed certificates.

### Related Issues:

Fixes #836