### PR TITLE
nodejs: Add 'build' and 'prune' lifecycle events

### DIFF
--- a/incubator/nodejs/README.md
+++ b/incubator/nodejs/README.md
@@ -42,7 +42,7 @@ Templates are used to create your local project and start your development. When
 
 ## Customizing the build
 
-Simple Node projects do not require a 'build' process: they are executed directly from source.  However, some technologies such as Typescipt require commands to be invoked to prepare the project ready to be run.
+Simple Node projects do not require a 'build' process: they are executed directly from source.  However, some technologies such as TypeScript require commands to be invoked to prepare the project ready to be run.
 
 If your project's dependencies require an additional build step, you can do so as follows:
 

--- a/incubator/nodejs/README.md
+++ b/incubator/nodejs/README.md
@@ -40,6 +40,20 @@ Templates are used to create your local project and start your development. When
 
     **NOTE:** Currently the `appsody deploy` command only works for deploying web applications.
 
+## Customizing the build
+
+Simple Node projects do not require a 'build' process: they are executed directly from source.  However, some technologies such as Typescipt require commands to be invoked to prepare the project ready to be run.
+
+If your project's dependencies require an additional build step, you can do so as follows:
+
+- In your `package.json`, edit the `"scripts"` section and define two new scripts:
+  - `"build": "npm install && <build commands>"`
+  - `"prune": "<cleanup commands> && npm prune"`
+
+When initially launching your app using `appsody run`, or building the production image with `appsody build`, the 'build' script is executed (if one exists).  Your build script should invoke `npm install` if any dependencies specified in your `devDependencies` are required as part of the build process - such as command line tools.
+
+When generating the production image, the 'prune' script is executed after that, if it exists, and is run with the `--production` flag.  This allows the removal of development dependencies that were required during the 'build' step.  This could be as simple as running the `npm prune` command, which inherits the production flag, and restores the dependencies to a production state.  You may also use this step to clean up any build artifacts that are not necessary in your production image.
+
 ## License
 
 This stack is licensed under the [Apache 2.0](./image/LICENSE) license

--- a/incubator/nodejs/image/Dockerfile-stack
+++ b/incubator/nodejs/image/Dockerfile-stack
@@ -8,7 +8,7 @@ ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/node_modules
 ENV APPSODY_WATCH_REGEX="^.*.js$"
 
-ENV APPSODY_PREP="npm install"
+ENV APPSODY_PREP="npm install && npm run build --if-present"
 
 ENV APPSODY_RUN="npm start --node-options --require=appmetrics-dash/attach"
 ENV APPSODY_RUN_ON_CHANGE="npm start --node-options --require=appmetrics-dash/attach"

--- a/incubator/nodejs/image/project/Dockerfile
+++ b/incubator/nodejs/image/project/Dockerfile
@@ -8,7 +8,19 @@ RUN rm -rf /project/user-app/node_modules && mkdir -p /project/user-app/node_mod
 
 # Install user-app dependencies
 WORKDIR /project/user-app
-RUN npm install --production 
+RUN npm install --production
+
+# Run a build phase. Projects that need to execute build commands can customize the
+# 'build' script in their package.json. The build script should call 'npm install'.
+# If no build is required, just install production dependencies.
+RUN npm run build --if-present
+
+# Uninstall dev dependencies, leaving only production dependencies. Projects can
+# customize the 'prune' script in their package.json.
+# Ideally this would just be 'npm prune', but this command does not have pre/post
+# hooks. Instead, the user's 'prune' script can itself call 'npm prune' in addition
+# to any additional actions required.
+RUN npm run prune --production --if-present
 
 # Creating a tar to work around poor copy performance when using buildah 1.9.0
 RUN cd / && tar czf project.tgz project

--- a/incubator/nodejs/image/project/Dockerfile
+++ b/incubator/nodejs/image/project/Dockerfile
@@ -28,6 +28,9 @@ RUN cd / && tar czf project.tgz project
 # Copy the dependencies into a slim Node docker image
 FROM node:12-slim
 
+# Install common dependencies (TLS and CA support)
+RUN apt-get update && apt-get install -y libssl1.1 ca-certificates && apt-get clean
+
 # Copy project with dependencies
 COPY --chown=node:node --from=0 /project.tgz .
 RUN tar xf project.tgz && chown -R node:node project && rm project.tgz

--- a/incubator/nodejs/stack.yaml
+++ b/incubator/nodejs/stack.yaml
@@ -1,5 +1,5 @@
 name: Node.js
-version: 0.3.7
+version: 0.4.0
 description: Runtime for Node.js applications
 license: Apache-2.0
 language: nodejs


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

I added `npm build` and `npm prune` steps to the build process for the production image, to provide a point of customization in cases where the project needs to perform build actions (such as running the Angular or Typescript compiler).

The 'prune' step is required to remove any development dependencies, and/or perform any cleanup of artifacts generated during the build, which would otherwise bloat the final image. 

Although there is an `npm prune` command, it does not behave the same way as `install`, `test` etc in that it does not invoke any scripts in package.json (none of `prune`, `preprune`, `postprune` are run).  The only way to run a script called `prune` is to run `npm run prune` (which is what I've gone for).  It is run with `--production` so that the user's script can invoke `npm prune` (possibly in addition to other actions), and this will have the effect of running `npm prune --production`, which removes any development-only dependencies.

Update: I added libssl1.1 and ca-certificates.  This is required in order for the service to connect to others over https (with certificate verification), which I feel is a common enough requirement to be part of the base stack.

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
