### PR TITLE
Upgrade java-openliberty stack to Open Liberty 20.0.0.6

### DIFF
--- a/incubator/java-openliberty/README.md
+++ b/incubator/java-openliberty/README.md
@@ -4,7 +4,7 @@ The Open Liberty stack provides a consistent way of developing microservices bas
 
 The Open Liberty stack uses a parent Maven project object model (POM) to manage dependency versions and provide required capabilities and plugins.
 
-This stack is based on OpenJDK with container-optimizations in OpenJ9 and `Open Liberty v20.0.0.3`. It provides live reloading during development by utilizing the "dev mode" capability in the liberty-maven-plugin.  To see dev mode in action (though not in Appsody) check out this [shorter demo](https://openliberty.io/blog/2019/10/22/liberty-dev-mode.html) and this  [a bit longer demo](https://blog.sebastian-daschner.com/entries/openliberty-plugin-dev-mode).
+This stack is based on OpenJDK with container-optimizations in OpenJ9 and `Open Liberty v20.0.0.6`. It provides live reloading during development by utilizing the "dev mode" capability in the liberty-maven-plugin.  To see dev mode in action (though not in Appsody) check out this [shorter demo](https://openliberty.io/blog/2019/10/22/liberty-dev-mode.html) and this  [a bit longer demo](https://blog.sebastian-daschner.com/entries/openliberty-plugin-dev-mode).
 
 **Note:** Maven is provided by the Appsody stack container, allowing you to build, test, and debug your Java application without installing Maven locally. However, we recommend installing Maven locally for the best IDE experience.
 

--- a/incubator/java-openliberty/stack.yaml
+++ b/incubator/java-openliberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Open Liberty
-version: 0.2.14
+version: 0.2.15
 description: Eclipse MicroProfile & Jakarta EE on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java
@@ -21,7 +21,7 @@ requirements:
     docker-version: ">= 17.09.0"
     appsody-version: ">= 0.5.0"
 templating-data:
-    libertyversion: '20.0.0.3'
+    libertyversion: '20.0.0.6'
     parentpomgroup: 'dev.appsody'
     parentpomid: 'java-openliberty'
     parentpomrange: '[0.2, 0.3)'


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Update Open Liberty fix pack 20.0.0.3 => 20.0.0.6
