### PR TITLE
Add instructions for using starter app in nodejs-express Kafka template readme.

### DIFF
--- a/incubator/nodejs-express/stack.yaml
+++ b/incubator/nodejs-express/stack.yaml
@@ -1,5 +1,5 @@
 name: Node.js Express
-version: 0.4.14
+version: 0.4.13
 description: Express web framework for Node.js
 license: Apache-2.0
 language: nodejs

--- a/incubator/nodejs-express/stack.yaml
+++ b/incubator/nodejs-express/stack.yaml
@@ -1,5 +1,5 @@
 name: Node.js Express
-version: 0.4.13
+version: 0.4.14
 description: Express web framework for Node.js
 license: Apache-2.0
 language: nodejs

--- a/incubator/nodejs-express/templates/kafka/README.md
+++ b/incubator/nodejs-express/templates/kafka/README.md
@@ -9,11 +9,12 @@ to publish and subscribe to Kafka using
 
 Create a new folder in your local directory and initialize it using the Appsody CLI, e.g.:
 
-    ```bash
-    mkdir my-project
-    cd my-project
-    appsody init nodejs-express kafka
-    ```
+```bash
+mkdir my-project
+cd my-project
+appsody init nodejs-express kafka
+```
+
 This will initialize a Node.js Express project using the `kafka` template.
     
 ### Start Kafka and Zookeeper
@@ -22,7 +23,7 @@ In order to run the starter app.js you must start Kafka and ZooKeeper containers
 
 Start docker compose with the following command:
     
-    ```docker-compose up```
+```docker-compose up```
     
 Run ```docker network list``` to see your new network with the name of your project directory and the word ```_default``` appended. For example, ```my-project_default```. This is your `DOCKER_NETWORK_NAME`.
 
@@ -30,14 +31,14 @@ Run ```docker network list``` to see your new network with the name of your proj
 
 After your project has been initialized you can then run your application using the following command:
 
-    ```bash
-    appsody run --docker-options "--env KAFKA_BOOTSTRAP_SERVERS=${KAFKA_BOOTSTRAP_SERVERS}"
-    ```
+```bash
+appsody run --docker-options "--env KAFKA_BOOTSTRAP_SERVERS=${KAFKA_BOOTSTRAP_SERVERS}"
+```
 
-    E.g:
-    ```
-    appsody run --network DOCKER_NETWORK_NAME --docker-options "--env KAFKA_BOOTSTRAP_SERVERS=kafka:9092"
-    ```
+E.g:
+```bash
+appsody run --network DOCKER_NETWORK_NAME --docker-options "--env KAFKA_BOOTSTRAP_SERVERS=kafka:9092"
+```
 
 This template expects `KAFKA_BOOTSTRAP_SERVERS` environment variable to be set to addresses of the bootstrap servers of kafka.
 
@@ -72,16 +73,16 @@ This will start consuming messages from when it is initiated so now you can prod
 ### Deploy to Kubernetes
 
 To deploy the application to Kubernetes run the following command:
-    ```bash
-    appsody deploy
-    ```
+```bash
+appsody deploy
+```
 Make sure to add the `KAFKA_BOOTSTRAP_SERVERS` environment variable in the `app-deploy.yaml` before running the above command
 
-    ```yaml
-    env:
-      - name: KAFKA_BOOTSTRAP_SERVERS
-        value: ${KAFKA_BOOTSTRAP_SERVERS}
-    ```
+```yaml
+env:
+- name: KAFKA_BOOTSTRAP_SERVERS
+  value: ${KAFKA_BOOTSTRAP_SERVERS}
+```
 
 If you are trying to connect to a Kafka instance managed by Strimzi Kafka operator, the value of `KAFKA_BOOTSTRAP_SERVERS` should be a fully qualified service hostname.
 

--- a/incubator/nodejs-express/templates/kafka/README.md
+++ b/incubator/nodejs-express/templates/kafka/README.md
@@ -23,7 +23,9 @@ In order to run the starter app.js you must start Kafka and ZooKeeper containers
 
 Start docker compose with the following command:
     
-```docker-compose up```
+```
+docker-compose up
+```
     
 Run ```docker network list``` to see your new network with the name of your project directory and the word ```_default``` appended. For example, ```my-project_default```. This is your `DOCKER_NETWORK_NAME`.
 

--- a/incubator/nodejs-express/templates/kafka/README.md
+++ b/incubator/nodejs-express/templates/kafka/README.md
@@ -46,15 +46,21 @@ This template expects `KAFKA_BOOTSTRAP_SERVERS` environment variable to be set t
 
 You can either POST to the /produce endpoint. This must be in json format if you are using the starter application, for example:
 
-```curl -d '{"foo":"bar"}' -H 'Content-Type: application/json' http://localhost:<port>/produce```
+```
+curl -d '{"foo":"bar"}' -H 'Content-Type: application/json' http://localhost:<port>/produce
+```
 
 or you can start a Kafka producer. You will first need to run another container in the same network:
 
-```docker run -it --network my-project_default strimzi/kafka:0.16.0-kafka-2.4.0 /bin/bash```
+```
+docker run -it --network my-project_default strimzi/kafka:0.16.0-kafka-2.4.0 /bin/bash
+```
 
 Now we can produce a message to ```my-topic``` by running:
 
-```bin/kafka-console-producer.sh --broker-list kafka:9092 --topic my-topic```
+```
+bin/kafka-console-producer.sh --broker-list kafka:9092 --topic my-topic
+```
 
 Type a message in the console. 
 
@@ -62,11 +68,15 @@ Type a message in the console.
 
 Start another container in the same network, as before, for the consumer:
 
-```docker run -it --network my-node-project_default  strimzi/kafka:0.16.0-kafka-2.4.0 /bin/bash```
+```
+docker run -it --network my-node-project_default  strimzi/kafka:0.16.0-kafka-2.4.0 /bin/bash
+```
 
 To consume messages you can run the following command:
 
-```bin/kafka-console-consumer.sh --bootstrap-server kafka:9092 --topic my-topic --from-beginning```
+```
+bin/kafka-console-consumer.sh --bootstrap-server kafka:9092 --topic my-topic --from-beginning
+```
 
 This will start consuming messages from when it is initiated so now you can produce some more messages and you should see them. 
 

--- a/incubator/nodejs-express/templates/kafka/README.md
+++ b/incubator/nodejs-express/templates/kafka/README.md
@@ -5,38 +5,77 @@ to publish and subscribe to Kafka using
 [node-rdkafka](https://www.npmjs.com/package/node-rdkafka).
 
 
-## Getting Started
+### Create an Appsody Project
 
-1. Create a new folder in your local directory and initialize it using the Appsody CLI, e.g.:
+Create a new folder in your local directory and initialize it using the Appsody CLI, e.g.:
 
     ```bash
     mkdir my-project
     cd my-project
     appsody init nodejs-express kafka
     ```
+This will initialize a Node.js Express project using the `kafka` template.
+    
+### Start Kafka and Zookeeper
 
-    This will initialize a Node.js Express project using the `kafka` template.
+In order to run the starter app.js you must start Kafka and ZooKeeper containers. ZooKeeper is a dependency of Kafka. Use the docker-compose.yaml that is provided in the template to start both containers.
 
-1. After your project has been initialized you can then run your application using the following command:
+Start docker compose with the following command:
+    
+    ```docker-compose up```
+    
+Run ```docker network list``` to see your new network with the name of your project directory and the word ```_default``` appended. For example, ```my-project_default```. This is your `DOCKER_NETWORK_NAME`.
+
+### Run the Appsody application
+
+After your project has been initialized you can then run your application using the following command:
 
     ```bash
     appsody run --docker-options "--env KAFKA_BOOTSTRAP_SERVERS=${KAFKA_BOOTSTRAP_SERVERS}"
     ```
 
-E.g:
-```
-appsody run --network DOCKER_NETWORK_NAME --docker-options "--env KAFKA_BOOTSTRAP_SERVERS=kafka:9092"
-```
-`DOCKER_NETWORK_NAME` is the name of the docker network in which the kafka container is running.
+    E.g:
+    ```
+    appsody run --network DOCKER_NETWORK_NAME --docker-options "--env KAFKA_BOOTSTRAP_SERVERS=kafka:9092"
+    ```
 
-This template expects `KAFKA_BOOTSTRAP_SERVERS` environment variable to be set
-to addresses of the bootstrap servers of kafka.
+This template expects `KAFKA_BOOTSTRAP_SERVERS` environment variable to be set to addresses of the bootstrap servers of kafka.
 
-1. To deploy the application to Kubernetes run the following command:
+### Produce a message to a Kafka topic
+
+You can either POST to the /produce endpoint. This must be in json format if you are using the starter application, for example:
+
+```curl -d '{"foo":"bar"}' -H 'Content-Type: application/json' http://localhost:<port>/produce```
+
+or you can start a Kafka producer. You will first need to run another container in the same network:
+
+```docker run -it --network my-project_default strimzi/kafka:0.16.0-kafka-2.4.0 /bin/bash```
+
+Now we can produce a message to ```my-topic``` by running:
+
+```bin/kafka-console-producer.sh --broker-list kafka:9092 --topic my-topic```
+
+Type a message in the console. 
+
+### Consume a message from a Kafka topic
+
+Start another container in the same network, as before, for the consumer:
+
+```docker run -it --network my-node-project_default  strimzi/kafka:0.16.0-kafka-2.4.0 /bin/bash```
+
+To consume messages you can run the following command:
+
+```bin/kafka-console-consumer.sh --bootstrap-server kafka:9092 --topic my-topic --from-beginning```
+
+This will start consuming messages from when it is initiated so now you can produce some more messages and you should see them. 
+
+### Deploy to Kubernetes
+
+To deploy the application to Kubernetes run the following command:
     ```bash
     appsody deploy
     ```
-    Make sure to add the `KAFKA_BOOTSTRAP_SERVERS` environment variable in the `app-deploy.yaml` before running the above command
+Make sure to add the `KAFKA_BOOTSTRAP_SERVERS` environment variable in the `app-deploy.yaml` before running the above command
 
     ```yaml
     env:
@@ -44,15 +83,15 @@ to addresses of the bootstrap servers of kafka.
         value: ${KAFKA_BOOTSTRAP_SERVERS}
     ```
 
-    If you are trying to connect to a Kafka instance managed by Strimzi Kafka operator, the value of `KAFKA_BOOTSTRAP_SERVERS` should be a fully qualified service hostname.
+If you are trying to connect to a Kafka instance managed by Strimzi Kafka operator, the value of `KAFKA_BOOTSTRAP_SERVERS` should be a fully qualified service hostname.
 
-    E.g: my-cluster-kafka-bootstrap.strimzi.svc.cluster.local:9092
+E.g: my-cluster-kafka-bootstrap.strimzi.svc.cluster.local:9092
 
     * `my-cluster` is the Kafka resource name.
     * `kafka-bootstrap` is the Broker load balancer name.
     * `strimzi` is the namespace in which Kafka instance is deployed.
     * `9092` is the PLAINTEXT port.
-
+     
 
 ## License
 


### PR DESCRIPTION
The current readme doesn't show the user how to interact with the starter app.js so it could be quite confusing if they are new to kafka. I have added some new instructions for producing and consuming messages and restructured it a bit.

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [x] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
Fixes #848
