### PR TITLE
Pull in kabanero/ubi8-maven:0.10.2

### DIFF
--- a/incubator/java-openliberty/image/Dockerfile-stack
+++ b/incubator/java-openliberty/image/Dockerfile-stack
@@ -1,4 +1,4 @@
-FROM kabanero/ubi8-maven:0.9.0
+FROM kabanero/ubi8-maven:0.10.2
 
 LABEL vendor="Open Liberty" \
     name="{{.stack.id}}" \

--- a/incubator/java-openliberty/image/project/Dockerfile
+++ b/incubator/java-openliberty/image/project/Dockerfile
@@ -1,5 +1,5 @@
 # Step 1: Build the user's application
-FROM kabanero/ubi8-maven:0.9.0 as compile
+FROM kabanero/ubi8-maven:0.10.2 as compile
 
 RUN  groupadd java_group \
    && useradd --gid java_group --shell /bin/bash --create-home java_user \

--- a/incubator/java-openliberty/stack.yaml
+++ b/incubator/java-openliberty/stack.yaml
@@ -1,5 +1,5 @@
 name: Open Liberty
-version: 0.2.16
+version: 0.2.17
 description: Eclipse MicroProfile & Jakarta EE on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

### Modifying an existing stack:

Update java-openliberty to 0.2.17 to pick up updates in base image (both stack image and appsody build image).
